### PR TITLE
Lualine background color fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change terminal background color to `bg` #2
 - Fold Bright background fixed #5
 - Added option to customize statusline background with `bg_statusline` #11
+- Lualine `c` section background color get dark color `bg2`
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/lualine/themes/github.lua
+++ b/lua/lualine/themes/github.lua
@@ -9,7 +9,7 @@ return {
   normal = {
     a = {bg = colors.blue, fg = colors.bg},
     b = {bg = colors.bg2, fg = colors.blue},
-    c = {bg = colors.bg2, fg = colors.fg_light}
+    c = {bg = colors.bg, fg = colors.fg_light}
   },
   insert = {
     a = {bg = colors.green, fg = colors.bg},

--- a/lua/lualine/themes/github.lua
+++ b/lua/lualine/themes/github.lua
@@ -9,7 +9,7 @@ return {
   normal = {
     a = {bg = colors.blue, fg = colors.bg},
     b = {bg = colors.bg2, fg = colors.blue},
-    c = {bg = colors.bg_statusline, fg = colors.fg_light}
+    c = {bg = colors.bg, fg = colors.fg_light}
   },
   insert = {
     a = {bg = colors.green, fg = colors.bg},

--- a/lua/lualine/themes/github.lua
+++ b/lua/lualine/themes/github.lua
@@ -9,7 +9,7 @@ return {
   normal = {
     a = {bg = colors.blue, fg = colors.bg},
     b = {bg = colors.bg2, fg = colors.blue},
-    c = {bg = colors.bg, fg = colors.fg_light}
+    c = {bg = colors.bg2, fg = colors.fg_light}
   },
   insert = {
     a = {bg = colors.green, fg = colors.bg},


### PR DESCRIPTION
### Problem Description:
After setting the `blue` color to `bg_statusline`, it's inherited inside the lualine `c` section.

### Changes:
- set `bg` color inside `c` section of lualine theme

#### bug
![image](https://user-images.githubusercontent.com/24286590/125160301-d2ee2380-e199-11eb-884a-14af2f512ae1.png)

#### patch
![image](https://user-images.githubusercontent.com/24286590/125160331-f31de280-e199-11eb-8dca-8f817988dca4.png)
