### PR TITLE
Change `commentTSConstant` highlight to `c.syntax.keyword`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added option to customize statusline background with `bg_statusline` #11
 - Lualine `c` section background color get dark color `bg2`
 - illuminate plugin highlights fixed #10
+- Change `commentTSConstant` highlight to `c.syntax.keyword` from `c.syntax.commentConstant`
+- Removed `commentConstant` color
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/README.md
+++ b/README.md
@@ -250,21 +250,6 @@ require("github-theme").setup({
   <img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" >
 </a>
 
-#### TODO:
-
-- [x] Init
-- [x] Dynamic theme for `lualine`
-- [ ] Ask for using github-vscode-theme branding logo (primer/github-vscode-theme#186)
-- [x] Support highlight for almost every language.
-- [x] Previews & Customization docs inside README.md
-- [x] Better color grouping inside [colors.lua](./lua/github-theme/colors.lua)
-- [ ] Dynamic colors using [Primer color Palette](https://primer.style/primitives/)
-- [ ] Follow [Primer color system](https://primer.style/css/support/color-system)
-- [ ] Rewrite github-vscode-theme util functions inside lua
-- [ ] Add Github Light Classic & Github Dark Classic styles
-- [ ] Change NvimTreeIcon & DevIcons colors
-- [ ] Write tests
-
 <!-- Ninja  -->
 <p align="center">
   <h1 align="center">(◣_◢)</h1>

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -69,7 +69,6 @@ function M.setup(config)
     syntax = {
       comment = themes({dark = "#6a737d", dimmed = "#768390", light = "#6a737d"}),
       constant = themes({dark = "#79b8ff", dimmed = "#6cb6ff", light = "#005cc5"}),
-      commentConstant = themes({dark = "#b392f0", dimmed = "#f69d50", light = "#6f42c1"}),
       string = themes({dark = "#9ecbff", dimmed = "#96d0ff", light = "#032f62"}),
       variable = themes({dark = "#79b8ff", dimmed = "#6cb6ff", light = "#005cc5"}),
       keyword = themes({dark = "#f97583", dimmed = "#f47067", light = "#d73a49"}),

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -191,7 +191,7 @@ function M.setup(config)
     TSConstructor = {fg = c.syntax.variable}, -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     -- TSConditional       = { };    -- For keywords related to conditionnals.
     TSConstant = {fg = c.syntax.constant}, -- For constants
-    commentTSConstant = {fg = c.syntax.commentConstant},
+    commentTSConstant = {fg = c.syntax.keyword},
     -- TSConstBuiltin      = { };    -- For constant that are built in the language: `nil` in Lua.
     -- TSConstMacro        = { };    -- For constants that are defined by macros: `NULL` in C.
     -- TSError             = { };    -- For syntax/parser errors.


### PR DESCRIPTION
### Changes
- Change `commentTSConstant` highlight to `c.syntax.keyword` from `c.syntax.commentConstant`
- Removed `commentConstant` color
- TODO list moved to #16 

#### Before
![image](https://user-images.githubusercontent.com/24286590/125437720-bfecacfc-147c-44e4-9c74-7a204e31c2d3.png)

#### Patch
![image](https://user-images.githubusercontent.com/24286590/125437628-1c7b74f8-db9e-4a18-9f3c-60b56aeebf1f.png)
