### PR TITLE
Additional plugin support (releated to #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `folded` colors are configurable
-- [Neogit](https://github.com/TimUntersberger/neogit) support
+- Plugin Support check #16
+- added iTerm colorscheme #14
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -13,19 +13,26 @@
 - minimal inactive statusline
 - vim terminal colors
 - darker background for sidebar-like windows
-- color configs for [Kitty](https://sw.kovidgoyal.net/kitty/conf.html?highlight=include) and [Alacritty](https://github.com/alacritty/alacritty)
+- color configs for [kitty](https://sw.kovidgoyal.net/kitty/conf.html?highlight=include),[iTerm2](https://iterm2.com/) and [Alacritty](https://github.com/alacritty/alacritty)
 - dynamic **lualine** theme
 
 ### Plugin Support
 
-- [TreeSitter](https://github.com/nvim-treesitter/nvim-treesitter)
-- [Telescope](https://github.com/nvim-telescope/telescope.nvim)
+- [ALE](https://github.com/dense-analysis/ale)
+- [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)
+- [Git Signs](https://github.com/lewis6991/gitsigns.nvim)
+- [Indent Blankline](https://github.com/lukas-reineke/indent-blankline.nvim)
 - [LSP Diagnostics](https://neovim.io/doc/user/lsp.html)
 - [LSP Trouble](https://github.com/folke/lsp-trouble.nvim)
-- [Git Signs](https://github.com/lewis6991/gitsigns.nvim)
+- [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim)
+- [Lualine](https://github.com/hoob3rt/lualine.nvim)
+- [nvim-bufferline.lua](https://github.com/akinsho/nvim-bufferline.lua)
 - [Neogit](https://github.com/TimUntersberger/neogit)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
-- [Lualine](https://github.com/hoob3rt/lualine.nvim)
+- [Telescope](https://github.com/nvim-telescope/telescope.nvim)
+- [TreeSitter](https://github.com/nvim-treesitter/nvim-treesitter)
+- [vim-gitgutter](https://github.com/airblade/vim-gitgutter)
+- [which-key.nvim](https://github.com/folke/which-key.nvim/)
 
 ## Requirements
 
@@ -132,7 +139,7 @@ set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{25
 
 > To generate the configs `make extra` or `:luafile lua/github-theme/extra/init.lua`
 
-Extra color configs for **Kitty**, and **Alacritty** can be found in [extras](extras/). To use them, refer to their respective documentation.
+Extra color configs for **kitty**, **iTerm**, and **Alacritty** can be found in [extras](extras/). To use them, refer to their respective documentation.
 
 ## Reference
 
@@ -241,7 +248,7 @@ require("github-theme").setup({
 
 ## Useful Links
 
-- Terminal: [Kitty](https://sw.kovidgoyal.net/kitty)
+- Terminal: [kitty](https://sw.kovidgoyal.net/kitty)
 - Font: [Ubuntu Mono](https://design.ubuntu.com/font/)
 - config: [dotfiles](https://github.com/ful1e5/dotfiles)
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -395,19 +395,18 @@ function M.setup(config)
     gitcommitSummary = {fg = c.syntax.tag},
 
     -- Dashboard
-    DashboardShortCut = {fg = c.magenta},
-    DashboardHeader = {fg = c.red},
-    DashboardCenter = {fg = c.blue},
-    DashboardFooter = {fg = c.yellow, style = "italic"},
+    DashboardHeader = {fg = c.blue},
+    DashboardCenter = {fg = c.green, style = "bold"},
+    DashboardShortCut = {fg = c.yellow},
+    DashboardFooter = {fg = c.brightWhite, style = "italic"},
 
     -- WhichKey
-    WhichKey = {fg = c.yellow},
-    WhichKeyGroup = {fg = c.blue},
-    WhichKeyDesc = {fg = c.red},
-    WhichKeySeperator = {fg = c.fg_gutter},
-    WhichKeySeparator = {fg = c.fg_gutter},
-    WhichKeyFloat = {bg = c.bg_sidebar},
-    WhichKeyValue = {fg = c.brightWhite},
+    WhichKey = {fg = c.blue}, -- the key
+    WhichKeyGroup = {fg = c.syntax.keyword}, -- a group
+    WhichKeySeperator = {fg = c.syntax.comment}, -- the separator between the key and its label
+    WhichKeyDesc = {fg = c.fg}, -- the label of the key
+    WhichKeyFloat = {bg = c.bg2}, -- Normal in the popup window
+    WhichKeyValue = {fg = c.syntax.comment}, -- used by plugins that provide values
 
     -- LspSaga
     DiagnosticError = {fg = c.error},
@@ -421,13 +420,12 @@ function M.setup(config)
     healthWarning = {fg = c.warning},
 
     -- BufferLine
-
-    BufferLineIndicatorSelected = {fg = c.git.change},
-    BufferLineFill = {bg = c.black},
+    BufferLineIndicatorSelected = {fg = c.blue},
+    BufferLineFill = {bg = c.bg2},
 
     -- ALE
-    ALEWarningSign = {fg = c.yellow},
-    ALEErrorSign = {fg = c.red}
+    ALEWarningSign = {fg = c.warning},
+    ALEErrorSign = {fg = c.error}
   }
 
   if config.hideInactiveStatusline then


### PR DESCRIPTION
### Changes
- Add **iTerm** support log inside `CHANGELOG.md` & `README.md`
- [README.md#plugin-support](https://github.com/projekt0n/github-nvim-theme#plugin-support) list updated
- **"kitty"** typo fixed inside `README.md`

### Plugin support
- [ALE](https://github.com/dense-analysis/ale)
- [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)
- [Indent Blankline](https://github.com/lukas-reineke/indent-blankline.nvim)
- [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim)
- [nvim-bufferline.lua](https://github.com/akinsho/nvim-bufferline.lua)
- [vim-gitgutter](https://github.com/airblade/vim-gitgutter)
- [which-key.nvim](https://github.com/folke/which-key.nvim/)

### Screenshots

#### `indent-blankline.nvim`
![Screenshot_20210715_121436](https://user-images.githubusercontent.com/24286590/125771027-b5f12230-f15c-4258-838c-64775c4a78fd.png)

#### `dashboard-nvim`
![Screenshot_20210715_122545](https://user-images.githubusercontent.com/24286590/125771094-32173929-5310-4f0a-85d7-616a2a623eaa.png)

#### `which-key.nvim`
![Screenshot_20210715_150851](https://user-images.githubusercontent.com/24286590/125771152-40a55b5b-2c33-485d-885e-3e49da95ea82.png)

#### `nvim-bufferline.lua`
![Screenshot_20210715_152424](https://user-images.githubusercontent.com/24286590/125771219-55bad5a6-a65c-44cb-a2fb-1c08fd6fa815.png)


