### PR TITLE
Regenerate terminal themes according to `colors.lua`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `folded` colors are configurable
 - Plugin Support check #16
 - added iTerm colorscheme #14
+- added Konsole colorscheme #33
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@
 - minimal inactive statusline
 - vim terminal colors
 - darker background for sidebar-like windows
-- color configs for [kitty](https://sw.kovidgoyal.net/kitty/conf.html?highlight=include),[iTerm2](https://iterm2.com/) and [Alacritty](https://github.com/alacritty/alacritty)
+- color configs for [kitty](https://sw.kovidgoyal.net/kitty/conf.html?highlight=include), [iTerm2](https://iterm2.com/), [Konsole](https://konsole.kde.org/) and [Alacritty](https://github.com/alacritty/alacritty)
 - dynamic **lualine** theme
+
+## Terminal Themes (Extras)
+
+> To generate the configs `make extra` or `:luafile lua/github-theme/extra/init.lua`
+
+Extra color configs for **kitty**, **iTerm**, **Konsole** and **Alacritty** can be found in [extras](extras/) directory. To use them, refer to their respective documentation.
 
 ### Plugin Support
 
@@ -134,12 +140,6 @@ set -g default-terminal "${TERM}"
 set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'  # undercurl support
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'  # underscore colours - needs tmux-3.0
 ```
-
-## Extras
-
-> To generate the configs `make extra` or `:luafile lua/github-theme/extra/init.lua`
-
-Extra color configs for **kitty**, **iTerm**, and **Alacritty** can be found in [extras](extras/). To use them, refer to their respective documentation.
 
 ## Reference
 

--- a/extras/alacritty_github_dark.yml
+++ b/extras/alacritty_github_dark.yml
@@ -7,7 +7,7 @@ colors:
 
   # Normal colors
   normal:
-    black:   '0x1D2125'
+    black:   '0x24292e'
     red:     '0xf14c4c'
     green:   '0x23d18b'
     yellow:  '0xe2e210'

--- a/extras/alacritty_github_dimmed.yml
+++ b/extras/alacritty_github_dimmed.yml
@@ -7,7 +7,7 @@ colors:
 
   # Normal colors
   normal:
-    black:   '0x1B1F25'
+    black:   '0x22272e'
     red:     '0xff938a'
     green:   '0x6bc46d'
     yellow:  '0xc69026'

--- a/extras/alacritty_github_light.yml
+++ b/extras/alacritty_github_light.yml
@@ -7,13 +7,13 @@ colors:
 
   # Normal colors
   normal:
-    black:   '0xCCCCCC'
+    black:   '0x697179'
     red:     '0xd03d3d'
     green:   '0x14ce14'
     yellow:  '0x949800'
     blue:    '0x0451a5'
     magenta: '0xbc05bc'
-    cyan:    '0x0598BC'
+    cyan:    '0x0598bc'
     white:   '0x586069'
 
   # Bright colors
@@ -24,7 +24,7 @@ colors:
     yellow:  '0xb5ba00'
     blue:    '0x0451a5'
     magenta: '0xbc05bc'
-    cyan:    '0x0598BC'
+    cyan:    '0x0598bc'
     white:   '0x586069'
 
   indexed_colors:

--- a/extras/iterm_github_dark.itermcolors
+++ b/extras/iterm_github_dark.itermcolors
@@ -2,7 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Ansi 1 Color</key>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4000000000000000</real>
+		<key>Green Component</key>
+		<real>0.4000000000000000</real>
+		<key>Red Component</key>
+		<real>0.4000000000000000</real>
+	</dict>
+	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -12,6 +23,61 @@
 		<real>0.2980392156862745</real>
 		<key>Red Component</key>
 		<real>0.9450980392156862</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.5450980392156862</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.1372549019607843</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1607843137254902</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8509803921568627</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.7882352941176470</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.9176470588235294</real>
+		<key>Green Component</key>
+		<real>0.5568627450980392</real>
+		<key>Red Component</key>
+		<real>0.2313725490196079</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.2627450980392157</real>
+		<key>Green Component</key>
+		<real>0.9607843137254902</real>
+		<key>Red Component</key>
+		<real>0.9607843137254902</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
@@ -35,71 +101,27 @@
 		<key>Red Component</key>
 		<real>0.8862745098039215</real>
 	</dict>
-	<key>Selected Text Color</key>
+	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.8509803921568627</real>
+		<real>0.8392156862745098</real>
 		<key>Green Component</key>
-		<real>0.8196078431372549</real>
+		<real>0.4392156862745098</real>
 		<key>Red Component</key>
-		<real>0.7882352941176470</real>
+		<real>0.8392156862745098</real>
 	</dict>
-	<key>Ansi 2 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5450980392156862</real>
-		<key>Green Component</key>
-		<real>0.8196078431372549</real>
-		<key>Red Component</key>
-		<real>0.1372549019607843</real>
-	</dict>
-	<key>Ansi 10 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5450980392156862</real>
-		<key>Green Component</key>
-		<real>0.8196078431372549</real>
-		<key>Red Component</key>
-		<real>0.1372549019607843</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
-		<key>Green Component</key>
-		<real>0.4000000000000000</real>
-		<key>Red Component</key>
-		<real>0.4000000000000000</real>
-	</dict>
-	<key>Selection Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
-		<key>Green Component</key>
-		<real>0.2705882352941176</real>
-		<key>Red Component</key>
-		<real>0.1568627450980392</real>
-	</dict>
-	<key>Ansi 15 Color</key>
+	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.8549019607843137</real>
 		<key>Green Component</key>
-		<real>0.8352941176470589</real>
+		<real>0.7176470588235294</real>
 		<key>Red Component</key>
-		<real>0.8196078431372549</real>
+		<real>0.1607843137254902</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
@@ -123,39 +145,6 @@
 		<key>Red Component</key>
 		<real>0.7882352941176470</real>
 	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9176470588235294</real>
-		<key>Green Component</key>
-		<real>0.5568627450980392</real>
-		<key>Red Component</key>
-		<real>0.2313725490196079</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.2980392156862745</real>
-		<key>Green Component</key>
-		<real>0.2980392156862745</real>
-		<key>Red Component</key>
-		<real>0.9450980392156862</real>
-	</dict>
-	<key>Cursor Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
-		<key>Green Component</key>
-		<real>0.1607843137254902</real>
-		<key>Red Component</key>
-		<real>0.1411764705882353</real>
-	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -167,16 +156,38 @@
 		<key>Red Component</key>
 		<real>0.7882352941176470</real>
 	</dict>
-	<key>Ansi 7 Color</key>
+	<key>Selection Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.4000000000000000</real>
 		<key>Green Component</key>
-		<real>0.4000000000000000</real>
+		<real>0.2705882352941176</real>
 		<key>Red Component</key>
-		<real>0.4000000000000000</real>
+		<real>0.1568627450980392</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8549019607843137</real>
+		<key>Green Component</key>
+		<real>0.8352941176470589</real>
+		<key>Red Component</key>
+		<real>0.8196078431372549</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.5450980392156862</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.1372549019607843</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
@@ -189,6 +200,17 @@
 		<key>Red Component</key>
 		<real>0.7372549019607844</real>
 	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4000000000000000</real>
+		<key>Green Component</key>
+		<real>0.4000000000000000</real>
+		<key>Red Component</key>
+		<real>0.4000000000000000</real>
+	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -200,40 +222,7 @@
 		<key>Red Component</key>
 		<real>0.7843137254901961</real>
 	</dict>
-	<key>Ansi 0 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1450980392156863</real>
-		<key>Green Component</key>
-		<real>0.1294117647058824</real>
-		<key>Red Component</key>
-		<real>0.1137254901960784</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8549019607843137</real>
-		<key>Green Component</key>
-		<real>0.7176470588235294</real>
-		<key>Red Component</key>
-		<real>0.1607843137254902</real>
-	</dict>
-	<key>Ansi 11 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.2627450980392157</real>
-		<key>Green Component</key>
-		<real>0.9607843137254902</real>
-		<key>Red Component</key>
-		<real>0.9607843137254902</real>
-	</dict>
-	<key>Background Color</key>
+	<key>Cursor Text Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -244,16 +233,27 @@
 		<key>Red Component</key>
 		<real>0.1411764705882353</real>
 	</dict>
-	<key>Ansi 13 Color</key>
+	<key>Ansi 0 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.8392156862745098</real>
+		<real>0.1803921568627451</real>
 		<key>Green Component</key>
-		<real>0.4392156862745098</real>
+		<real>0.1607843137254902</real>
 		<key>Red Component</key>
-		<real>0.8392156862745098</real>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.2980392156862745</real>
+		<key>Green Component</key>
+		<real>0.2980392156862745</real>
+		<key>Red Component</key>
+		<real>0.9450980392156862</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/iterm_github_dimmed.itermcolors
+++ b/extras/iterm_github_dimmed.itermcolors
@@ -2,7 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Ansi 1 Color</key>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4823529411764706</real>
+		<key>Green Component</key>
+		<real>0.4313725490196079</real>
+		<key>Red Component</key>
+		<real>0.3882352941176471</real>
+	</dict>
+	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -12,6 +23,61 @@
 		<real>0.5764705882352941</real>
 		<key>Red Component</key>
 		<real>1.0000000000000000</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4274509803921568</real>
+		<key>Green Component</key>
+		<real>0.7686274509803922</real>
+		<key>Red Component</key>
+		<real>0.4196078431372549</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1529411764705882</real>
+		<key>Red Component</key>
+		<real>0.1333333333333333</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.7803921568627451</real>
+		<key>Green Component</key>
+		<real>0.7294117647058823</real>
+		<key>Red Component</key>
+		<real>0.6784313725490196</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>0.7137254901960784</real>
+		<key>Red Component</key>
+		<real>0.4235294117647059</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.2470588235294118</real>
+		<key>Green Component</key>
+		<real>0.6666666666666666</real>
+		<key>Red Component</key>
+		<real>0.8549019607843137</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
@@ -35,71 +101,27 @@
 		<key>Red Component</key>
 		<real>0.7764705882352941</real>
 	</dict>
-	<key>Selected Text Color</key>
+	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.7803921568627451</real>
+		<real>0.9843137254901960</real>
 		<key>Green Component</key>
-		<real>0.7294117647058823</real>
+		<real>0.7411764705882353</real>
 		<key>Red Component</key>
-		<real>0.6784313725490196</real>
+		<real>0.8627450980392157</real>
 	</dict>
-	<key>Ansi 2 Color</key>
+	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.4274509803921568</real>
+		<real>0.8666666666666667</real>
 		<key>Green Component</key>
-		<real>0.7686274509803922</real>
+		<real>0.8313725490196079</real>
 		<key>Red Component</key>
-		<real>0.4196078431372549</real>
-	</dict>
-	<key>Ansi 10 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4274509803921568</real>
-		<key>Green Component</key>
-		<real>0.7686274509803922</real>
-		<key>Red Component</key>
-		<real>0.4196078431372549</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4823529411764706</real>
-		<key>Green Component</key>
-		<real>0.4313725490196079</real>
-		<key>Red Component</key>
-		<real>0.3882352941176471</real>
-	</dict>
-	<key>Selection Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
-		<key>Green Component</key>
-		<real>0.2666666666666667</real>
-		<key>Red Component</key>
-		<real>0.1490196078431373</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5647058823529412</real>
-		<key>Green Component</key>
-		<real>0.5137254901960784</real>
-		<key>Red Component</key>
-		<real>0.4627450980392157</real>
+		<real>0.3372549019607843</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
@@ -123,39 +145,6 @@
 		<key>Red Component</key>
 		<real>0.6784313725490196</real>
 	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
-		<key>Green Component</key>
-		<real>0.7137254901960784</real>
-		<key>Red Component</key>
-		<real>0.4235294117647059</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5411764705882353</real>
-		<key>Green Component</key>
-		<real>0.5764705882352941</real>
-		<key>Red Component</key>
-		<real>1.0000000000000000</real>
-	</dict>
-	<key>Cursor Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
-		<key>Green Component</key>
-		<real>0.1529411764705882</real>
-		<key>Red Component</key>
-		<real>0.1333333333333333</real>
-	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -167,16 +156,38 @@
 		<key>Red Component</key>
 		<real>0.6784313725490196</real>
 	</dict>
-	<key>Ansi 7 Color</key>
+	<key>Selection Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.4823529411764706</real>
+		<real>0.4000000000000000</real>
 		<key>Green Component</key>
-		<real>0.4313725490196079</real>
+		<real>0.2666666666666667</real>
 		<key>Red Component</key>
-		<real>0.3882352941176471</real>
+		<real>0.1490196078431373</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.5647058823529412</real>
+		<key>Green Component</key>
+		<real>0.5137254901960784</real>
+		<key>Red Component</key>
+		<real>0.4627450980392157</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4274509803921568</real>
+		<key>Green Component</key>
+		<real>0.7686274509803922</real>
+		<key>Red Component</key>
+		<real>0.4196078431372549</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
@@ -189,6 +200,17 @@
 		<key>Red Component</key>
 		<real>0.6901960784313725</real>
 	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4823529411764706</real>
+		<key>Green Component</key>
+		<real>0.4313725490196079</real>
+		<key>Red Component</key>
+		<real>0.3882352941176471</real>
+	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -200,40 +222,7 @@
 		<key>Red Component</key>
 		<real>0.4235294117647059</real>
 	</dict>
-	<key>Ansi 0 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1450980392156863</real>
-		<key>Green Component</key>
-		<real>0.1215686274509804</real>
-		<key>Red Component</key>
-		<real>0.1058823529411765</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8666666666666667</real>
-		<key>Green Component</key>
-		<real>0.8313725490196079</real>
-		<key>Red Component</key>
-		<real>0.3372549019607843</real>
-	</dict>
-	<key>Ansi 11 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.2470588235294118</real>
-		<key>Green Component</key>
-		<real>0.6666666666666666</real>
-		<key>Red Component</key>
-		<real>0.8549019607843137</real>
-	</dict>
-	<key>Background Color</key>
+	<key>Cursor Text Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -244,16 +233,27 @@
 		<key>Red Component</key>
 		<real>0.1333333333333333</real>
 	</dict>
-	<key>Ansi 13 Color</key>
+	<key>Ansi 0 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.9843137254901960</real>
+		<real>0.1803921568627451</real>
 		<key>Green Component</key>
-		<real>0.7411764705882353</real>
+		<real>0.1529411764705882</real>
 		<key>Red Component</key>
-		<real>0.8627450980392157</real>
+		<real>0.1333333333333333</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.5411764705882353</real>
+		<key>Green Component</key>
+		<real>0.5764705882352941</real>
+		<key>Red Component</key>
+		<real>1.0000000000000000</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/iterm_github_light.itermcolors
+++ b/extras/iterm_github_light.itermcolors
@@ -2,16 +2,82 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Ansi 1 Color</key>
+	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.2392156862745098</real>
+		<real>0.4000000000000000</real>
 		<key>Green Component</key>
-		<real>0.2392156862745098</real>
+		<real>0.4000000000000000</real>
 		<key>Red Component</key>
-		<real>0.8156862745098039</real>
+		<real>0.4000000000000000</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1921568627450981</real>
+		<key>Green Component</key>
+		<real>0.1921568627450981</real>
+		<key>Red Component</key>
+		<real>0.8039215686274510</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.0784313725490196</real>
+		<key>Green Component</key>
+		<real>0.8078431372549020</real>
+		<key>Red Component</key>
+		<real>0.0784313725490196</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>1.0000000000000000</real>
+		<key>Red Component</key>
+		<real>1.0000000000000000</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1607843137254902</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.6470588235294118</real>
+		<key>Green Component</key>
+		<real>0.3176470588235294</real>
+		<key>Red Component</key>
+		<real>0.0156862745098039</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.0000000000000000</real>
+		<key>Green Component</key>
+		<real>0.7294117647058823</real>
+		<key>Red Component</key>
+		<real>0.7098039215686275</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
@@ -35,71 +101,27 @@
 		<key>Red Component</key>
 		<real>0.5803921568627451</real>
 	</dict>
-	<key>Selected Text Color</key>
+	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
+		<real>0.7372549019607844</real>
 		<key>Green Component</key>
-		<real>0.1607843137254902</real>
+		<real>0.0196078431372549</real>
 		<key>Red Component</key>
-		<real>0.1411764705882353</real>
+		<real>0.7372549019607844</real>
 	</dict>
-	<key>Ansi 2 Color</key>
+	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.0784313725490196</real>
+		<real>0.7372549019607844</real>
 		<key>Green Component</key>
-		<real>0.8078431372549020</real>
+		<real>0.5960784313725490</real>
 		<key>Red Component</key>
-		<real>0.0784313725490196</real>
-	</dict>
-	<key>Ansi 10 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.0784313725490196</real>
-		<key>Green Component</key>
-		<real>0.8078431372549020</real>
-		<key>Red Component</key>
-		<real>0.0784313725490196</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
-		<key>Green Component</key>
-		<real>0.4000000000000000</real>
-		<key>Red Component</key>
-		<real>0.4000000000000000</real>
-	</dict>
-	<key>Selection Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9764705882352941</real>
-		<key>Green Component</key>
-		<real>0.9137254901960784</real>
-		<key>Red Component</key>
-		<real>0.8588235294117647</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4117647058823529</real>
-		<key>Green Component</key>
-		<real>0.3764705882352941</real>
-		<key>Red Component</key>
-		<real>0.3450980392156863</real>
+		<real>0.0196078431372549</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
@@ -123,39 +145,6 @@
 		<key>Red Component</key>
 		<real>0.1411764705882353</real>
 	</dict>
-	<key>Ansi 4 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6470588235294118</real>
-		<key>Green Component</key>
-		<real>0.3176470588235294</real>
-		<key>Red Component</key>
-		<real>0.0156862745098039</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1921568627450981</real>
-		<key>Green Component</key>
-		<real>0.1921568627450981</real>
-		<key>Red Component</key>
-		<real>0.8039215686274510</real>
-	</dict>
-	<key>Cursor Text Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
-		<key>Green Component</key>
-		<real>1.0000000000000000</real>
-		<key>Red Component</key>
-		<real>1.0000000000000000</real>
-	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -167,16 +156,38 @@
 		<key>Red Component</key>
 		<real>0.1411764705882353</real>
 	</dict>
-	<key>Ansi 7 Color</key>
+	<key>Selection Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
+		<real>0.9764705882352941</real>
 		<key>Green Component</key>
-		<real>0.4000000000000000</real>
+		<real>0.9137254901960784</real>
 		<key>Red Component</key>
-		<real>0.4000000000000000</real>
+		<real>0.8588235294117647</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4117647058823529</real>
+		<key>Green Component</key>
+		<real>0.3764705882352941</real>
+		<key>Red Component</key>
+		<real>0.3450980392156863</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.0784313725490196</real>
+		<key>Green Component</key>
+		<real>0.8078431372549020</real>
+		<key>Red Component</key>
+		<real>0.0784313725490196</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
@@ -189,6 +200,17 @@
 		<key>Red Component</key>
 		<real>0.7372549019607844</real>
 	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4000000000000000</real>
+		<key>Green Component</key>
+		<real>0.4000000000000000</real>
+		<key>Red Component</key>
+		<real>0.4000000000000000</real>
+	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -200,60 +222,38 @@
 		<key>Red Component</key>
 		<real>0.0156862745098039</real>
 	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>1.0000000000000000</real>
+		<key>Red Component</key>
+		<real>1.0000000000000000</real>
+	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.8000000000000000</real>
+		<real>0.4745098039215686</real>
 		<key>Green Component</key>
-		<real>0.8000000000000000</real>
+		<real>0.4431372549019608</real>
 		<key>Red Component</key>
-		<real>0.8000000000000000</real>
+		<real>0.4117647058823529</real>
 	</dict>
-	<key>Ansi 6 Color</key>
+	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.7372549019607844</real>
+		<real>0.2392156862745098</real>
 		<key>Green Component</key>
-		<real>0.5960784313725490</real>
+		<real>0.2392156862745098</real>
 		<key>Red Component</key>
-		<real>0.0196078431372549</real>
-	</dict>
-	<key>Ansi 11 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.0000000000000000</real>
-		<key>Green Component</key>
-		<real>0.7294117647058823</real>
-		<key>Red Component</key>
-		<real>0.7098039215686275</real>
-	</dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
-		<key>Green Component</key>
-		<real>1.0000000000000000</real>
-		<key>Red Component</key>
-		<real>1.0000000000000000</real>
-	</dict>
-	<key>Ansi 13 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7372549019607844</real>
-		<key>Green Component</key>
-		<real>0.0196078431372549</real>
-		<key>Red Component</key>
-		<real>0.7372549019607844</real>
+		<real>0.8156862745098039</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/kitty_github_dark.conf
+++ b/extras/kitty_github_dark.conf
@@ -12,10 +12,9 @@ active_tab_background #3b8eea
 active_tab_foreground #1f2428
 inactive_tab_background #d1d5da
 inactive_tab_foreground #1f2428
-#tab_bar_background #1D2125
 
 # normal
-color0 #1D2125
+color0 #24292e
 color1 #f14c4c
 color2 #23d18b
 color3 #e2e210

--- a/extras/kitty_github_dimmed.conf
+++ b/extras/kitty_github_dimmed.conf
@@ -12,10 +12,9 @@ active_tab_background #6cb6ff
 active_tab_foreground #1e2228
 inactive_tab_background #768390
 inactive_tab_foreground #1e2228
-#tab_bar_background #1B1F25
 
 # normal
-color0 #1B1F25
+color0 #22272e
 color1 #ff938a
 color2 #6bc46d
 color3 #c69026

--- a/extras/kitty_github_light.conf
+++ b/extras/kitty_github_light.conf
@@ -12,16 +12,15 @@ active_tab_background #0451a5
 active_tab_foreground #f6f8fa
 inactive_tab_background #586069
 inactive_tab_foreground #f6f8fa
-#tab_bar_background #CCCCCC
 
 # normal
-color0 #CCCCCC
+color0 #697179
 color1 #d03d3d
 color2 #14ce14
 color3 #949800
 color4 #0451a5
 color5 #bc05bc
-color6 #0598BC
+color6 #0598bc
 color7 #666666
 
 # bright

--- a/extras/konsole_github_dark.colorscheme
+++ b/extras/konsole_github_dark.colorscheme
@@ -9,10 +9,10 @@ Color=36,41,46
 Color=36,41,46
 
 [Color0]
-Color=29,33,37
+Color=36,41,46
 
 [Color0Faint]
-Color=29,33,37
+Color=36,41,46
 
 [Color0Intense]
 Color=102,102,102

--- a/extras/konsole_github_dimmed.colorscheme
+++ b/extras/konsole_github_dimmed.colorscheme
@@ -9,10 +9,10 @@ Color=34,39,46
 Color=34,39,46
 
 [Color0]
-Color=27,31,37
+Color=34,39,46
 
 [Color0Faint]
-Color=27,31,37
+Color=34,39,46
 
 [Color0Intense]
 Color=99,110,123

--- a/extras/konsole_github_light.colorscheme
+++ b/extras/konsole_github_light.colorscheme
@@ -9,10 +9,10 @@ Color=255,255,255
 Color=255,255,255
 
 [Color0]
-Color=204,204,204
+Color=105,113,121
 
 [Color0Faint]
-Color=204,204,204
+Color=105,113,121
 
 [Color0Intense]
 Color=102,102,102

--- a/lua/github-theme/extra/iterm.lua
+++ b/lua/github-theme/extra/iterm.lua
@@ -41,12 +41,6 @@ function M.iterm(config)
   local itermColor = {
     Ansi__0 = rgb(colors.black),
     Ansi__1 = rgb(colors.red),
-    Ansi__10 = rgb(colors.brightGreen),
-    Ansi__11 = rgb(colors.brightYellow),
-    Ansi__12 = rgb(colors.brightBlue),
-    Ansi__13 = rgb(colors.brightMagenta),
-    Ansi__14 = rgb(colors.brightCyan),
-    Ansi__15 = rgb(colors.term_fg),
     Ansi__2 = rgb(colors.green),
     Ansi__3 = rgb(colors.yellow),
     Ansi__4 = rgb(colors.blue),
@@ -55,13 +49,19 @@ function M.iterm(config)
     Ansi__7 = rgb(colors.fg_dark),
     Ansi__8 = rgb(colors.fg_dark),
     Ansi__9 = rgb(colors.brightRed),
+    Ansi__10 = rgb(colors.brightGreen),
+    Ansi__11 = rgb(colors.brightYellow),
+    Ansi__12 = rgb(colors.brightBlue),
+    Ansi__13 = rgb(colors.brightMagenta),
+    Ansi__14 = rgb(colors.brightCyan),
+    Ansi__15 = rgb(colors.term_fg),
     Background = rgb(colors.bg),
-    Bold = rgb(colors.fg),
+    Foreground = rgb(colors.fg),
     Cursor = rgb(colors.cursor),
     Cursor__Text = rgb(colors.bg),
-    Foreground = rgb(colors.fg),
     Selected__Text = rgb(colors.fg),
-    Selection = rgb(colors.bg_visual_selection)
+    Selection = rgb(colors.bg_visual_selection),
+    Bold = rgb(colors.fg)
   }
 
   local iterm = [[
@@ -82,4 +82,3 @@ function M.iterm(config)
 end
 
 return M
-

--- a/lua/github-theme/extra/kitty.lua
+++ b/lua/github-theme/extra/kitty.lua
@@ -23,7 +23,6 @@ active_tab_background ${blue}
 active_tab_foreground ${bg2}
 inactive_tab_background ${term_fg}
 inactive_tab_foreground ${bg2}
-#tab_bar_background ${black}
 
 # normal
 color0 ${black}


### PR DESCRIPTION
### Changes:
- Added Konsole theme log inside `CHANGELOG.md`
- **README.md#extra** renamed to `README.md#terminal-themes`
- `black` and `cyan` color hex changed
- Re-ordered key sections inside `lua/extra/iterm.lua`
- Removed comment from `kitty` themes