### PR TITLE
`TabLineSel` barely readable foreground color fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - lualine `command` background fixed #30
 - Make window-separator(`VertSplit`) highlight bright (related to #16)
 - Removed unnecessary colors from `colors.lua`
+- Enhanced `TabLineSel` is barely readable foreground color fixed #35
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -68,7 +68,7 @@ function M.setup(config)
     StatusLineNC = {fg = c.fg, bg = c.bg}, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
     TabLine = {bg = c.bg, fg = c.fg}, -- tab pages line, not active tab page label
     TabLineFill = {bg = c.bg2}, -- tab pages line, where there are no labels
-    TabLineSel = {fg = c.fg, bg = c.blue}, -- tab pages line, active tab page label
+    TabLineSel = {fg = c.pmenu.select, bg = c.blue}, -- tab pages line, active tab page label
     Title = {fg = c.syntax.variable, style = "bold"}, -- titles for output from ":set all", ":autocmd" etc.
     Visual = {bg = c.bg_visual_selection}, -- Visual mode selection
     VisualNOS = {bg = c.bg_visual_selection}, -- Visual mode selection when vim is "Not Owning the Selection".


### PR DESCRIPTION
## Changes
- Changed `TabLineSel` foreground color to `pmenu.select` fixed #35 

## Before
![Screenshot_20210717_160300](https://user-images.githubusercontent.com/24286590/126034330-8be08bc3-366a-4aab-8102-90bfa340ec67.png)
![Screenshot_20210717_160321](https://user-images.githubusercontent.com/24286590/126034334-d6ecac5b-8a17-4c9f-986e-ea8fba6e59db.png)
![Screenshot_20210717_160341](https://user-images.githubusercontent.com/24286590/126034335-7dacc2a1-d18f-4877-a716-76fc1172cd21.png)

## Enhancement

![Screenshot_20210717_160412](https://user-images.githubusercontent.com/24286590/126034339-6d68b2e2-7e8e-4bd1-ac72-56b3d6caef6c.png)
![Screenshot_20210717_160504](https://user-images.githubusercontent.com/24286590/126034343-b1e17dee-7a0f-4544-9b8d-768712756414.png)
![Screenshot_20210717_160451](https://user-images.githubusercontent.com/24286590/126034341-1640c918-8e11-4e8c-970b-01d19f08a992.png)

