### PR TITLE
Transparent mode enhacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make window-separator(`VertSplit`) highlight bright (related to #16)
 - Removed unnecessary colors from `colors.lua`
 - Enhanced `TabLineSel` is barely readable foreground color fixed #35
+- Enhanced `transparent` mode background color
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin Support check #16
 - added iTerm colorscheme #14
 - added Konsole colorscheme #33
+- `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
 
 ### Fixes
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -112,6 +112,7 @@ function M.setup(config)
   }
 
   util.bg = colors.bg
+  colors.bg = config.transparent and colors.none or colors.bg
 
   colors.fg_search = colors.none
   colors.border_highlight = colors.blue

--- a/lua/github-theme/util.lua
+++ b/lua/github-theme/util.lua
@@ -233,7 +233,10 @@ function util.color_overrides(colors, config)
       if type(colors[key]) == "table" then
         util.color_overrides(colors[key], {colors = value})
       else
-        if string.sub(value, 1, 1) == "#" then
+        if value:lower() == "none" then
+          -- set to none
+          colors[key] = "NONE"
+        elseif string.sub(value, 1, 1) == "#" then
           -- hex override
           colors[key] = value
         else


### PR DESCRIPTION
### Changes
- `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
- Enhanced `transparent` mode background color

### Before
![Screenshot_20210718_112311](https://user-images.githubusercontent.com/24286590/126057262-418496ad-df24-456c-80b7-7ff15d582717.png)

### Patch
![image](https://user-images.githubusercontent.com/24286590/126057255-d606df9e-10c9-4df4-baf8-e8d8b9e9a549.png)


