### PR TITLE
Add proper `Description` inside `konsole` theme (bug from #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added iTerm colorscheme #14
 - added Konsole colorscheme #33
 - `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
+- Terminal themes are structured through `extra/init.lua`
 
 ### Fixes
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary colors from `colors.lua`
 - Enhanced `TabLineSel` is barely readable foreground color fixed #35
 - Enhanced `transparent` mode background color
+- Add proper `Description` inside `konsole` theme (bug from #33)
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/extras/iterm/dark.itermcolors
+++ b/extras/iterm/dark.itermcolors
@@ -2,28 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Ansi 13 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8392156862745098</real>
-		<key>Green Component</key>
-		<real>0.4392156862745098</real>
-		<key>Red Component</key>
-		<real>0.8392156862745098</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7372549019607844</real>
-		<key>Green Component</key>
-		<real>0.2470588235294118</real>
-		<key>Red Component</key>
-		<real>0.7372549019607844</real>
-	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -35,82 +13,27 @@
 		<key>Red Component</key>
 		<real>0.7843137254901961</real>
 	</dict>
-	<key>Ansi 4 Color</key>
+	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.9176470588235294</real>
+		<real>0.5450980392156862</real>
 		<key>Green Component</key>
-		<real>0.5568627450980392</real>
+		<real>0.8196078431372549</real>
 		<key>Red Component</key>
-		<real>0.2313725490196079</real>
+		<real>0.1372549019607843</real>
 	</dict>
-	<key>Ansi 1 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.2980392156862745</real>
-		<key>Green Component</key>
-		<real>0.2980392156862745</real>
-		<key>Red Component</key>
-		<real>0.9450980392156862</real>
-	</dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
-		<key>Green Component</key>
-		<real>0.1607843137254902</real>
-		<key>Red Component</key>
-		<real>0.1411764705882353</real>
-	</dict>
-	<key>Ansi 6 Color</key>
+	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
 		<real>0.8549019607843137</real>
 		<key>Green Component</key>
-		<real>0.7176470588235294</real>
+		<real>0.8352941176470589</real>
 		<key>Red Component</key>
-		<real>0.1607843137254902</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
-		<key>Green Component</key>
-		<real>0.4000000000000000</real>
-		<key>Red Component</key>
-		<real>0.4000000000000000</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.0627450980392157</real>
-		<key>Green Component</key>
-		<real>0.8862745098039215</real>
-		<key>Red Component</key>
-		<real>0.8862745098039215</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.2980392156862745</real>
-		<key>Green Component</key>
-		<real>0.2980392156862745</real>
-		<key>Red Component</key>
-		<real>0.9450980392156862</real>
+		<real>0.8196078431372549</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
@@ -122,6 +45,17 @@
 		<real>0.8196078431372549</real>
 		<key>Red Component</key>
 		<real>0.7882352941176470</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.2980392156862745</real>
+		<key>Green Component</key>
+		<real>0.2980392156862745</real>
+		<key>Red Component</key>
+		<real>0.9450980392156862</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
@@ -145,49 +79,16 @@
 		<key>Red Component</key>
 		<real>0.1607843137254902</real>
 	</dict>
-	<key>Ansi 11 Color</key>
+	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.2627450980392157</real>
+		<real>0.2980392156862745</real>
 		<key>Green Component</key>
-		<real>0.9607843137254902</real>
+		<real>0.2980392156862745</real>
 		<key>Red Component</key>
-		<real>0.9607843137254902</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8509803921568627</real>
-		<key>Green Component</key>
-		<real>0.8196078431372549</real>
-		<key>Red Component</key>
-		<real>0.7882352941176470</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8549019607843137</real>
-		<key>Green Component</key>
-		<real>0.8352941176470589</real>
-		<key>Red Component</key>
-		<real>0.8196078431372549</real>
-	</dict>
-	<key>Ansi 12 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9176470588235294</real>
-		<key>Green Component</key>
-		<real>0.5568627450980392</real>
-		<key>Red Component</key>
-		<real>0.2313725490196079</real>
+		<real>0.9450980392156862</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
@@ -200,27 +101,38 @@
 		<key>Red Component</key>
 		<real>0.7882352941176470</real>
 	</dict>
-	<key>Cursor Text Color</key>
+	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
+		<real>0.8549019607843137</real>
 		<key>Green Component</key>
+		<real>0.7176470588235294</real>
+		<key>Red Component</key>
 		<real>0.1607843137254902</real>
-		<key>Red Component</key>
-		<real>0.1411764705882353</real>
 	</dict>
-	<key>Ansi 10 Color</key>
+	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.5450980392156862</real>
+		<real>0.2627450980392157</real>
 		<key>Green Component</key>
-		<real>0.8196078431372549</real>
+		<real>0.9607843137254902</real>
 		<key>Red Component</key>
-		<real>0.1372549019607843</real>
+		<real>0.9607843137254902</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8392156862745098</real>
+		<key>Green Component</key>
+		<real>0.4392156862745098</real>
+		<key>Red Component</key>
+		<real>0.8392156862745098</real>
 	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
@@ -233,6 +145,50 @@
 		<key>Red Component</key>
 		<real>0.1411764705882353</real>
 	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1607843137254902</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8509803921568627</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.7882352941176470</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.9176470588235294</real>
+		<key>Green Component</key>
+		<real>0.5568627450980392</real>
+		<key>Red Component</key>
+		<real>0.2313725490196079</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4000000000000000</real>
+		<key>Green Component</key>
+		<real>0.4000000000000000</real>
+		<key>Red Component</key>
+		<real>0.4000000000000000</real>
+	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -244,7 +200,40 @@
 		<key>Red Component</key>
 		<real>0.4000000000000000</real>
 	</dict>
-	<key>Ansi 2 Color</key>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.7372549019607844</real>
+		<key>Green Component</key>
+		<real>0.2470588235294118</real>
+		<key>Red Component</key>
+		<real>0.7372549019607844</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1607843137254902</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.9176470588235294</real>
+		<key>Green Component</key>
+		<real>0.5568627450980392</real>
+		<key>Red Component</key>
+		<real>0.2313725490196079</real>
+	</dict>
+	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -254,6 +243,17 @@
 		<real>0.8196078431372549</real>
 		<key>Red Component</key>
 		<real>0.1372549019607843</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.0627450980392157</real>
+		<key>Green Component</key>
+		<real>0.8862745098039215</real>
+		<key>Red Component</key>
+		<real>0.8862745098039215</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/iterm/dimmed.itermcolors
+++ b/extras/iterm/dimmed.itermcolors
@@ -2,28 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Ansi 13 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9843137254901960</real>
-		<key>Green Component</key>
-		<real>0.7411764705882353</real>
-		<key>Red Component</key>
-		<real>0.8627450980392157</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.9411764705882353</real>
-		<key>Green Component</key>
-		<real>0.5137254901960784</real>
-		<key>Red Component</key>
-		<real>0.6901960784313725</real>
-	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -35,82 +13,27 @@
 		<key>Red Component</key>
 		<real>0.4235294117647059</real>
 	</dict>
-	<key>Ansi 4 Color</key>
+	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
+		<real>0.4274509803921568</real>
 		<key>Green Component</key>
-		<real>0.7137254901960784</real>
+		<real>0.7686274509803922</real>
 		<key>Red Component</key>
-		<real>0.4235294117647059</real>
+		<real>0.4196078431372549</real>
 	</dict>
-	<key>Ansi 1 Color</key>
+	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.5411764705882353</real>
-		<key>Green Component</key>
-		<real>0.5764705882352941</real>
-		<key>Red Component</key>
-		<real>1.0000000000000000</real>
-	</dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
-		<key>Green Component</key>
-		<real>0.1529411764705882</real>
-		<key>Red Component</key>
-		<real>0.1333333333333333</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.8666666666666667</real>
-		<key>Green Component</key>
-		<real>0.8313725490196079</real>
-		<key>Red Component</key>
-		<real>0.3372549019607843</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4823529411764706</real>
-		<key>Green Component</key>
-		<real>0.4313725490196079</real>
-		<key>Red Component</key>
-		<real>0.3882352941176471</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1490196078431373</real>
-		<key>Green Component</key>
 		<real>0.5647058823529412</real>
-		<key>Red Component</key>
-		<real>0.7764705882352941</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5411764705882353</real>
 		<key>Green Component</key>
-		<real>0.5764705882352941</real>
+		<real>0.5137254901960784</real>
 		<key>Red Component</key>
-		<real>1.0000000000000000</real>
+		<real>0.4627450980392157</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
@@ -122,6 +45,17 @@
 		<real>0.7294117647058823</real>
 		<key>Red Component</key>
 		<real>0.6784313725490196</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.5411764705882353</real>
+		<key>Green Component</key>
+		<real>0.5764705882352941</real>
+		<key>Red Component</key>
+		<real>1.0000000000000000</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
@@ -145,49 +79,16 @@
 		<key>Red Component</key>
 		<real>0.3372549019607843</real>
 	</dict>
-	<key>Ansi 11 Color</key>
+	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.2470588235294118</real>
+		<real>0.5411764705882353</real>
 		<key>Green Component</key>
-		<real>0.6666666666666666</real>
+		<real>0.5764705882352941</real>
 		<key>Red Component</key>
-		<real>0.8549019607843137</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7803921568627451</real>
-		<key>Green Component</key>
-		<real>0.7294117647058823</real>
-		<key>Red Component</key>
-		<real>0.6784313725490196</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.5647058823529412</real>
-		<key>Green Component</key>
-		<real>0.5137254901960784</real>
-		<key>Red Component</key>
-		<real>0.4627450980392157</real>
-	</dict>
-	<key>Ansi 12 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
 		<real>1.0000000000000000</real>
-		<key>Green Component</key>
-		<real>0.7137254901960784</real>
-		<key>Red Component</key>
-		<real>0.4235294117647059</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
@@ -200,27 +101,38 @@
 		<key>Red Component</key>
 		<real>0.6784313725490196</real>
 	</dict>
-	<key>Cursor Text Color</key>
+	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
+		<real>0.8666666666666667</real>
 		<key>Green Component</key>
-		<real>0.1529411764705882</real>
+		<real>0.8313725490196079</real>
 		<key>Red Component</key>
-		<real>0.1333333333333333</real>
+		<real>0.3372549019607843</real>
 	</dict>
-	<key>Ansi 10 Color</key>
+	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.4274509803921568</real>
+		<real>0.2470588235294118</real>
 		<key>Green Component</key>
-		<real>0.7686274509803922</real>
+		<real>0.6666666666666666</real>
 		<key>Red Component</key>
-		<real>0.4196078431372549</real>
+		<real>0.8549019607843137</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.9843137254901960</real>
+		<key>Green Component</key>
+		<real>0.7411764705882353</real>
+		<key>Red Component</key>
+		<real>0.8627450980392157</real>
 	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
@@ -233,6 +145,50 @@
 		<key>Red Component</key>
 		<real>0.1333333333333333</real>
 	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1529411764705882</real>
+		<key>Red Component</key>
+		<real>0.1333333333333333</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.7803921568627451</real>
+		<key>Green Component</key>
+		<real>0.7294117647058823</real>
+		<key>Red Component</key>
+		<real>0.6784313725490196</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>0.7137254901960784</real>
+		<key>Red Component</key>
+		<real>0.4235294117647059</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4823529411764706</real>
+		<key>Green Component</key>
+		<real>0.4313725490196079</real>
+		<key>Red Component</key>
+		<real>0.3882352941176471</real>
+	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -244,7 +200,40 @@
 		<key>Red Component</key>
 		<real>0.3882352941176471</real>
 	</dict>
-	<key>Ansi 2 Color</key>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.9411764705882353</real>
+		<key>Green Component</key>
+		<real>0.5137254901960784</real>
+		<key>Red Component</key>
+		<real>0.6901960784313725</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1529411764705882</real>
+		<key>Red Component</key>
+		<real>0.1333333333333333</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>0.7137254901960784</real>
+		<key>Red Component</key>
+		<real>0.4235294117647059</real>
+	</dict>
+	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -254,6 +243,17 @@
 		<real>0.7686274509803922</real>
 		<key>Red Component</key>
 		<real>0.4196078431372549</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1490196078431373</real>
+		<key>Green Component</key>
+		<real>0.5647058823529412</real>
+		<key>Red Component</key>
+		<real>0.7764705882352941</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/iterm/light.itermcolors
+++ b/extras/iterm/light.itermcolors
@@ -2,28 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Ansi 13 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7372549019607844</real>
-		<key>Green Component</key>
-		<real>0.0196078431372549</real>
-		<key>Red Component</key>
-		<real>0.7372549019607844</real>
-	</dict>
-	<key>Ansi 5 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7372549019607844</real>
-		<key>Green Component</key>
-		<real>0.0196078431372549</real>
-		<key>Red Component</key>
-		<real>0.7372549019607844</real>
-	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -35,82 +13,27 @@
 		<key>Red Component</key>
 		<real>0.0156862745098039</real>
 	</dict>
-	<key>Ansi 4 Color</key>
+	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.6470588235294118</real>
+		<real>0.0784313725490196</real>
 		<key>Green Component</key>
-		<real>0.3176470588235294</real>
+		<real>0.8078431372549020</real>
 		<key>Red Component</key>
-		<real>0.0156862745098039</real>
+		<real>0.0784313725490196</real>
 	</dict>
-	<key>Ansi 1 Color</key>
+	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.2392156862745098</real>
+		<real>0.4117647058823529</real>
 		<key>Green Component</key>
-		<real>0.2392156862745098</real>
+		<real>0.3764705882352941</real>
 		<key>Red Component</key>
-		<real>0.8156862745098039</real>
-	</dict>
-	<key>Background Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
-		<key>Green Component</key>
-		<real>1.0000000000000000</real>
-		<key>Red Component</key>
-		<real>1.0000000000000000</real>
-	</dict>
-	<key>Ansi 6 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.7372549019607844</real>
-		<key>Green Component</key>
-		<real>0.5960784313725490</real>
-		<key>Red Component</key>
-		<real>0.0196078431372549</real>
-	</dict>
-	<key>Ansi 8 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4000000000000000</real>
-		<key>Green Component</key>
-		<real>0.4000000000000000</real>
-		<key>Red Component</key>
-		<real>0.4000000000000000</real>
-	</dict>
-	<key>Ansi 3 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.0000000000000000</real>
-		<key>Green Component</key>
-		<real>0.5960784313725490</real>
-		<key>Red Component</key>
-		<real>0.5803921568627451</real>
-	</dict>
-	<key>Ansi 9 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1921568627450981</real>
-		<key>Green Component</key>
-		<real>0.1921568627450981</real>
-		<key>Red Component</key>
-		<real>0.8039215686274510</real>
+		<real>0.3450980392156863</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
@@ -122,6 +45,17 @@
 		<real>0.1607843137254902</real>
 		<key>Red Component</key>
 		<real>0.1411764705882353</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.2392156862745098</real>
+		<key>Green Component</key>
+		<real>0.2392156862745098</real>
+		<key>Red Component</key>
+		<real>0.8156862745098039</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
@@ -145,49 +79,16 @@
 		<key>Red Component</key>
 		<real>0.0196078431372549</real>
 	</dict>
-	<key>Ansi 11 Color</key>
+	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.0000000000000000</real>
+		<real>0.1921568627450981</real>
 		<key>Green Component</key>
-		<real>0.7294117647058823</real>
+		<real>0.1921568627450981</real>
 		<key>Red Component</key>
-		<real>0.7098039215686275</real>
-	</dict>
-	<key>Foreground Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.1803921568627451</real>
-		<key>Green Component</key>
-		<real>0.1607843137254902</real>
-		<key>Red Component</key>
-		<real>0.1411764705882353</real>
-	</dict>
-	<key>Ansi 15 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.4117647058823529</real>
-		<key>Green Component</key>
-		<real>0.3764705882352941</real>
-		<key>Red Component</key>
-		<real>0.3450980392156863</real>
-	</dict>
-	<key>Ansi 12 Color</key>
-	<dict>
-		<key>Color Space</key>
-		<string>sRGB</string>
-		<key>Blue Component</key>
-		<real>0.6470588235294118</real>
-		<key>Green Component</key>
-		<real>0.3176470588235294</real>
-		<key>Red Component</key>
-		<real>0.0156862745098039</real>
+		<real>0.8039215686274510</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
@@ -200,27 +101,38 @@
 		<key>Red Component</key>
 		<real>0.1411764705882353</real>
 	</dict>
-	<key>Cursor Text Color</key>
+	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>1.0000000000000000</real>
+		<real>0.7372549019607844</real>
 		<key>Green Component</key>
-		<real>1.0000000000000000</real>
+		<real>0.5960784313725490</real>
 		<key>Red Component</key>
-		<real>1.0000000000000000</real>
+		<real>0.0196078431372549</real>
 	</dict>
-	<key>Ansi 10 Color</key>
+	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.0784313725490196</real>
+		<real>0.0000000000000000</real>
 		<key>Green Component</key>
-		<real>0.8078431372549020</real>
+		<real>0.7294117647058823</real>
 		<key>Red Component</key>
-		<real>0.0784313725490196</real>
+		<real>0.7098039215686275</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.7372549019607844</real>
+		<key>Green Component</key>
+		<real>0.0196078431372549</real>
+		<key>Red Component</key>
+		<real>0.7372549019607844</real>
 	</dict>
 	<key>Ansi 0 Color</key>
 	<dict>
@@ -233,6 +145,50 @@
 		<key>Red Component</key>
 		<real>0.4117647058823529</real>
 	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>1.0000000000000000</real>
+		<key>Red Component</key>
+		<real>1.0000000000000000</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Green Component</key>
+		<real>0.1607843137254902</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.6470588235294118</real>
+		<key>Green Component</key>
+		<real>0.3176470588235294</real>
+		<key>Red Component</key>
+		<real>0.0156862745098039</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.4000000000000000</real>
+		<key>Green Component</key>
+		<real>0.4000000000000000</real>
+		<key>Red Component</key>
+		<real>0.4000000000000000</real>
+	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Color Space</key>
@@ -244,7 +200,40 @@
 		<key>Red Component</key>
 		<real>0.4000000000000000</real>
 	</dict>
-	<key>Ansi 2 Color</key>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.7372549019607844</real>
+		<key>Green Component</key>
+		<real>0.0196078431372549</real>
+		<key>Red Component</key>
+		<real>0.7372549019607844</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0000000000000000</real>
+		<key>Green Component</key>
+		<real>1.0000000000000000</real>
+		<key>Red Component</key>
+		<real>1.0000000000000000</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.6470588235294118</real>
+		<key>Green Component</key>
+		<real>0.3176470588235294</real>
+		<key>Red Component</key>
+		<real>0.0156862745098039</real>
+	</dict>
+	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Color Space</key>
 		<string>sRGB</string>
@@ -254,6 +243,17 @@
 		<real>0.8078431372549020</real>
 		<key>Red Component</key>
 		<real>0.0784313725490196</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.0000000000000000</real>
+		<key>Green Component</key>
+		<real>0.5960784313725490</real>
+		<key>Red Component</key>
+		<real>0.5803921568627451</real>
 	</dict>
 </dict>
 </plist>

--- a/extras/konsole/dark.colorscheme
+++ b/extras/konsole/dark.colorscheme
@@ -90,6 +90,6 @@ Color=209,213,218
 Color=209,213,218
 
 [General]
-Description=Github
+Description=Github Dark
 Opacity=1
 Wallpaper=

--- a/extras/konsole/dimmed.colorscheme
+++ b/extras/konsole/dimmed.colorscheme
@@ -90,6 +90,6 @@ Color=118,131,144
 Color=118,131,144
 
 [General]
-Description=Github
+Description=Github Dimmed
 Opacity=1
 Wallpaper=

--- a/extras/konsole/light.colorscheme
+++ b/extras/konsole/light.colorscheme
@@ -90,6 +90,6 @@ Color=88,96,105
 Color=88,96,105
 
 [General]
-Description=Github
+Description=Github Light
 Opacity=1
 Wallpaper=

--- a/lua/github-theme/extra/init.lua
+++ b/lua/github-theme/extra/init.lua
@@ -3,17 +3,23 @@ package.path = "./lua/?/init.lua;./lua/?.lua"
 local configModule = require("github-theme.config")
 
 local function write(str, fileName)
-  print("[write] extra/" .. fileName)
-  local file = io.open("extras/" .. fileName, "w")
+  print("[write]" .. fileName)
+  local file = io.open(fileName, "w")
   file:write(str)
   file:close()
 end
 
-local extras = {kitty = "conf", alacritty = "yml", iterm = "itermcolors", konsole="colorscheme"}
+local extras = {
+  kitty = "conf",
+  alacritty = "yml",
+  iterm = "itermcolors",
+  konsole = "colorscheme"
+}
 for _, style in ipairs({"dark", "dimmed", "light"}) do
   configModule.themeStyle = style
   for extra, ext in pairs(extras) do
     local plugin = require("github-theme.extra." .. extra)
-    write(plugin[extra](configModule), extra .. "_github_" .. style .. "." .. ext)
+    local fileName = "extras/" .. extra .. "/" .. style .. "." .. ext
+    write(plugin[extra](configModule), fileName)
   end
 end

--- a/lua/github-theme/extra/konsole.lua
+++ b/lua/github-theme/extra/konsole.lua
@@ -4,8 +4,11 @@ local configModule = require("github-theme.config")
 local M = {}
 
 function M.Hex2rgb(hex)
-    hex = hex:gsub("#","")
-    return table.concat({tonumber("0x"..hex:sub(1,2)), tonumber("0x"..hex:sub(3,4)), tonumber("0x"..hex:sub(5,6))}, ',')
+  hex = hex:gsub("#", "")
+  return table.concat({
+    tonumber("0x" .. hex:sub(1, 2)), tonumber("0x" .. hex:sub(3, 4)),
+    tonumber("0x" .. hex:sub(5, 6))
+  }, ",")
 end
 
 function M.konsole(config)
@@ -17,6 +20,8 @@ function M.konsole(config)
   for k, v in pairs(colors) do
     if type(v) == "string" then konsoleColors[k] = M.Hex2rgb(v) end
   end
+
+  local description = "Github " .. config.themeStyle:lower():gsub("^%l", string.upper)
 
   local konsole = util.template([[
 # github Konsole Colors
@@ -110,8 +115,10 @@ Color=${term_fg}
 [ForegroundIntense]
 Color=${term_fg}
 
+]] .. [[
 [General]
-Description=Github
+Description=]] .. description .. [[
+
 Opacity=1
 Wallpaper=
 ]], konsoleColors)


### PR DESCRIPTION
### Changes
- Terminal themes are structured through `extra/init.lua`
- Add proper `Description` inside `konsole` theme (bug from #33)