### PR TITLE
Area for messages and cmdline with `bold` text highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added Konsole colorscheme #33
 - `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
 - Terminal themes are structured through `extra/init.lua`
+- Area for messages and cmdline with `bold` text highlight
 
 ### Fixes
 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced `TabLineSel` is barely readable foreground color fixed #35
 - Enhanced `transparent` mode background color
 - Add proper `Description` inside `konsole` theme (bug from #33)
+- Lualine `normal` section background color set blue color #43
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -42,7 +42,7 @@ function M.setup(config)
     CursorLineNr = {fg = c.cursor_line_nr}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {bg = c.syntax.matchParenBG, fg = c.fg}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")
-    MsgArea = {fg = c.fg}, -- Area for messages and cmdline
+    MsgArea = {fg = c.fg, style = "bold"}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     MoreMsg = {fg = c.blue}, -- |more-prompt|
     NonText = {fg = c.bg}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.


### PR DESCRIPTION
### Changes
- Area for messages and cmdline with `bold` text highlight
- Update `CHANGELOG.md` logs.

### Before
![image](https://user-images.githubusercontent.com/24286590/126619212-d550c7d3-5f90-48f9-842a-11c1450595c9.png)


### Patch
![Screenshot_20210722_150803](https://user-images.githubusercontent.com/24286590/126619247-c5c1947b-ebd0-4eda-86b2-ea780c0d05b1.png)

