### PR TITLE
`hideEndOfBuffer` options added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
 - Terminal themes are structured through `extra/init.lua`
 - Area for messages and cmdline with `bold` text highlight
+- `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ require('lualine').setup {
 | functionStyle          | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
 | variableStyle          | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
 | transparent            | `false`  | Enable this to disable setting the background color                                                                                                             |
+| hideEndOfBuffer        | `true`   | Enabling this option, will hide filler lines (~) after the end of the buffer                                                                                    |
 | hideInactiveStatusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
 | sidebars               | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
 | darkSidebar            | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -114,6 +114,13 @@ function M.setup(config)
   util.bg = colors.bg
   colors.bg = config.transparent and colors.none or colors.bg
 
+  -- EndOfBuffer colors are configurable
+  colors.sidebar_eob = config.darkSidebar and colors.bg2 or colors.bg
+  colors.sidebar_eob = config.hideEndOfBuffer and colors.sidebar_eob or colors.fg_light
+  colors.sidebar_eob = config.transparent and colors.fg_light or colors.sidebar_eob
+  colors.eob = config.hideEndOfBuffer and colors.bg or colors.fg_light
+  colors.eob = config.transparent and colors.fg_light or colors.eob
+
   colors.fg_search = colors.none
   colors.border_highlight = colors.blue
   colors.bg_statusline = colors.blue

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -15,6 +15,7 @@ config = {
   functionStyle = "NONE",
   variableStyle = "NONE",
   hideInactiveStatusline = false,
+  hideEndOfBuffer = true,
   sidebars = {},
   colors = {},
   dev = false,

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -28,7 +28,7 @@ function M.setup(config)
     DiffChange = {bg = c.diff.change}, -- diff mode: Changed line |diff.txt|
     DiffDelete = {bg = c.diff.delete}, -- diff mode: Deleted line |diff.txt|
     DiffText = {bg = c.fg_gutter}, -- diff mode: Changed text within a changed line |diff.txt|
-    EndOfBuffer = {fg = c.bg}, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+    EndOfBuffer = {fg = c.eob}, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
     -- TermCursor  = { }, -- cursor in a focused terminal
     -- TermCursorNC= { }, -- cursor in an unfocused terminal
     ErrorMsg = {fg = c.error}, -- error messages on the command line
@@ -374,7 +374,7 @@ function M.setup(config)
 
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},
-    NvimTreeEndOfBuffer = config.darkSidebar and {fg = c.bg2} or {fg = c.bg},
+    NvimTreeEndOfBuffer = {fg = c.sidebar_eob},
     NvimTreeRootFolder = {fg = c.fg_light, style = "bold"},
     NvimTreeGitDirty = {fg = c.git.change},
     NvimTreeGitNew = {fg = c.git.add},


### PR DESCRIPTION
Enabling this option, will hide filler lines (~) after the end of the buffer.

### Default Value
`true`

### Changes
- Separated colors for EndOfBuffer inisde colors.lua ( `eob` & `sidebar_eob` )
- Updated CHANGELOG.md
- Information added inisde README.md
- used `eob` & `sidebar_eob` colors inside theme.lua

### Previews

#### Dark
##### `hideEndOfBuffer = true`
![image](https://user-images.githubusercontent.com/24286590/126773959-d480fe51-a261-4a63-98f2-3712b230af85.png)
##### `hideEndOfBuffer = false`
![image](https://user-images.githubusercontent.com/24286590/126774818-cb014074-7c63-4ce6-910c-584fe0725d2a.png)

#### Dimmed
##### `hideEndOfBuffer = true`
![image](https://user-images.githubusercontent.com/24286590/126774786-d5690aa2-4516-42ac-89d0-d6654e0b0b93.png)
##### `hideEndOfBuffer = false`
![image](https://user-images.githubusercontent.com/24286590/126774754-141f3902-3279-4697-95bb-ba90efa9cb66.png)



#### Light
##### `hideEndOfBuffer = true`
![image](https://user-images.githubusercontent.com/24286590/126774636-d08ead00-6875-4f22-ba10-8a005be53638.png)
##### `hideEndOfBuffer = false`
![image](https://user-images.githubusercontent.com/24286590/126774689-1b5a4021-34f4-4460-aa49-7ff670953e38.png)





