### PR TITLE
Kitty Windows border color fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ kitty_pre:
 	@touch $(theme)
 
 kitty_dark: kitty_pre
-	@cat $(exts)/kitty_github_dark.conf > $(theme)
+	@cat $(exts)/kitty/dark.conf > $(theme)
 
 kitty_dimmed: kitty_pre
-	@cat $(exts)/kitty_github_dimmed.conf > $(theme)
+	@cat $(exts)/kitty/dimmed.conf > $(theme)
 
 kitty_light: kitty_pre
-	@cat $(exts)/kitty_github_light.conf > $(theme)
+	@cat $(exts)/kitty/light.conf > $(theme)

--- a/extras/kitty/dark.conf
+++ b/extras/kitty/dark.conf
@@ -13,6 +13,10 @@ active_tab_foreground #1f2428
 inactive_tab_background #d1d5da
 inactive_tab_foreground #1f2428
 
+# Windows Border
+active_border_color #444c56
+inactive_border_color #444c56
+
 # normal
 color0 #24292e
 color1 #f14c4c

--- a/extras/kitty/dimmed.conf
+++ b/extras/kitty/dimmed.conf
@@ -13,6 +13,10 @@ active_tab_foreground #1e2228
 inactive_tab_background #768390
 inactive_tab_foreground #1e2228
 
+# Windows Border
+active_border_color #444c56
+inactive_border_color #444c56
+
 # normal
 color0 #22272e
 color1 #ff938a

--- a/extras/kitty/light.conf
+++ b/extras/kitty/light.conf
@@ -13,6 +13,10 @@ active_tab_foreground #f6f8fa
 inactive_tab_background #586069
 inactive_tab_foreground #f6f8fa
 
+# Windows Border
+active_border_color #e1e4e8
+inactive_border_color #e1e4e8
+
 # normal
 color0 #697179
 color1 #d03d3d

--- a/lua/github-theme/extra/kitty.lua
+++ b/lua/github-theme/extra/kitty.lua
@@ -24,6 +24,10 @@ active_tab_foreground ${bg2}
 inactive_tab_background ${term_fg}
 inactive_tab_foreground ${bg2}
 
+# Windows Border
+active_border_color ${bg_visual}
+inactive_border_color ${bg_visual}
+
 # normal
 color0 ${black}
 color1 ${red}


### PR DESCRIPTION
### Changes
- `make` commands source file path updated as of #39 
- `active_border_color` & `inactive_border_color` colors added inside kitty themes

### Before
#### `dark` theme
![image](https://user-images.githubusercontent.com/24286590/126777022-8d9f37d1-0402-41bd-bfc7-3e08a0fb57cd.png)
#### `dimmed` theme
![image](https://user-images.githubusercontent.com/24286590/126777226-d872d26a-efcb-4e85-96be-9282bca6ef40.png)
#### `light` theme
![image](https://user-images.githubusercontent.com/24286590/126777413-c065a452-d9a6-43ab-a222-f37c72c6fb99.png)

### Patch
#### `dark` theme
![image](https://user-images.githubusercontent.com/24286590/126777138-af25bab5-829d-42bd-a1a2-e6147876e797.png)
#### `dimmed` theme
![image](https://user-images.githubusercontent.com/24286590/126777291-7c6e2744-576f-4a1a-aa3e-b1ac473964ee.png)
#### `light` theme
![image](https://user-images.githubusercontent.com/24286590/126777473-d8da2153-6ebe-493b-9f64-0302df39e466.png)

