### PR TITLE
`BufferLine` slant style separator color fixed ( related to #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added Konsole colorscheme #33
 - `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
 - Terminal themes are structured through `extra/init.lua`
-- Area for messages and cmdline with `bold` text highlight
-- `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer
+- Area for messages and cmdline with `bold` text highlight #44
+- `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
 
 ### Fixes
 
@@ -32,9 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make window-separator(`VertSplit`) highlight bright (related to #16)
 - Removed unnecessary colors from `colors.lua`
 - Enhanced `TabLineSel` is barely readable foreground color fixed #35
-- Enhanced `transparent` mode background color
+- Enhanced `transparent` mode background color #41
 - Add proper `Description` inside `konsole` theme (bug from #33)
 - Lualine `normal` section background color set blue color #43
+- Kitty window border colors fix #47
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add proper `Description` inside `konsole` theme (bug from #33)
 - Lualine `normal` section background color set blue color #43
 - Kitty window border colors fix #47
+- BufferLine slant style separator color fixed ( related to #16)
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -422,6 +422,9 @@ function M.setup(config)
     -- BufferLine
     BufferLineIndicatorSelected = {fg = c.blue},
     BufferLineFill = {bg = c.bg2},
+    BufferLineSeparator = {fg = c.bg2},
+    BufferLineSeparatorSelected = {fg = c.bg2},
+    BufferLineSeparatorVisible = {fg = c.bg2},
 
     -- ALE
     ALEWarningSign = {fg = c.warning},


### PR DESCRIPTION
### Changes
- Linked PR inside `CHANGELOG.md`
- `BufferLine` slant style separator color fixed ( related to #16)

### Bug
![image](https://user-images.githubusercontent.com/24286590/126865149-3632b20a-59dc-49d9-a81c-33c01c9856bf.png)

### Patch
![image](https://user-images.githubusercontent.com/24286590/126865185-3491e4f4-0e4e-4bad-9543-dc067eef0cad.png)
