### PR TITLE
feat: `nvim-compe` plugin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminal themes are structured through `extra/init.lua`
 - Area for messages and cmdline with `bold` text highlight #44
 - `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
+- `nvim-compe` plugin support
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Extra color configs for **kitty**, **iTerm**, **Konsole** and **Alacritty** can 
 - [nvim-bufferline.lua](https://github.com/akinsho/nvim-bufferline.lua)
 - [Neogit](https://github.com/TimUntersberger/neogit)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
+- [nvim-compe](https://github.com/hrsh7th/nvim-compe)
 - [Telescope](https://github.com/nvim-telescope/telescope.nvim)
 - [TreeSitter](https://github.com/nvim-treesitter/nvim-treesitter)
 - [vim-gitgutter](https://github.com/airblade/vim-gitgutter)

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -1,8 +1,6 @@
 ---@class Config
 local config
 
-local vimConfig = false
-
 local themeStyleKey = "github_theme_style"
 -- shim vim for kitty and other generators
 vim = vim or {g = {}, o = {}}
@@ -46,11 +44,10 @@ local function getThemeStyle()
   else
     return vim.g[themeStyleKey]
   end
-
 end
+
 return {
   config = config,
-  vimConfig = vimConfig,
   applyConfiguration = applyConfiguration,
   getThemeStyle = getThemeStyle
 }

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -359,6 +359,10 @@ function M.setup(config)
     NeogitDiffDeleteHighlight = {fg = c.diff.delete_fg, bg = c.diff.delete},
     NeogitDiffAddHighlight = {fg = c.diff.add_fg, bg = c.diff.add},
 
+    -- Compe
+    CompeDocumentationBorder = {fg = c.blue, bg = c.bg_float},
+    CompeDocumentation = {fg = c.fg, bg = c.bg_float},
+
     -- GitGutter
     GitGutterAdd = {fg = c.gitSigns.add}, -- diff mode: Added line |diff.txt|
     GitGutterChange = {fg = c.gitSigns.change}, -- diff mode: Changed line |diff.txt|


### PR DESCRIPTION
### Changes:
- `nvim-compe` highlight group added inisde `themes.lua`
- Removed `vimConfig` from `config.lua`

### Preview
#### Dark
![image](https://user-images.githubusercontent.com/24286590/127125871-1fc5c6f8-f713-4007-bc82-219a714cdf47.png)
#### Dimmed
![image](https://user-images.githubusercontent.com/24286590/127125493-56ed1143-87c9-4f92-a77c-d10e0bb1cfea.png)
#### Light
![image](https://user-images.githubusercontent.com/24286590/127125764-4d021198-797f-493b-9858-cd16cfaef8d1.png)
