### PR TITLE
fix: Floating Windows background with `transparent` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lualine `normal` section background color set blue color #43
 - Kitty window border colors fix #47
 - BufferLine slant style separator color fixed ( related to #16)
+- Floating Windows background on `transparent` mode
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -136,6 +136,7 @@ function M.setup(config)
   colors.bg_sidebar = config.darkSidebar and colors.bg2 or colors.bg
   colors.bg_sidebar = config.transparent and colors.none or colors.bg_sidebar
   colors.bg_float = config.darkFloat and colors.bg2 or colors.bg
+  colors.bg_float = config.transparent and colors.none or colors.bg_float
 
   util.color_overrides(colors, config)
 


### PR DESCRIPTION
### Bug
![Screenshot_20210727_174727](https://user-images.githubusercontent.com/24286590/127155837-e8195fe4-431c-4aec-b570-4c0b760b39c2.png)

### Patch
![Screenshot_20210727_174809](https://user-images.githubusercontent.com/24286590/127155843-f1b6228f-1427-4e40-af1b-eedd3b2e0237.png)
