### PR TITLE
`barbar.nvim` plugins support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terminal themes are structured through `extra/init.lua`
 - Area for messages and cmdline with `bold` text highlight #44
 - `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
-- `nvim-compe` plugin support
+- `nvim-compe`, `barbar.nvim` plugins support
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Extra color configs for **kitty**, **iTerm**, **Konsole** and **Alacritty** can 
 ### Plugin Support
 
 - [ALE](https://github.com/dense-analysis/ale)
+- [barbar.nvim](https://github.com/romgrk/barbar.nvim)
 - [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)
 - [Git Signs](https://github.com/lewis6991/gitsigns.nvim)
 - [Indent Blankline](https://github.com/lukas-reineke/indent-blankline.nvim)

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -258,7 +258,7 @@ function M.setup(config)
     javascriptTSParameter = {fg = c.syntax.param},
     javascriptTSVariable = {fg = c.syntax.variable},
     javascriptTSPunctDelimiter = {fg = c.fg},
-    javascriptTSStringRegex = {fg = c.string},
+    javascriptTSStringRegex = {fg = c.lsp.string},
     javascriptTSConstructor = {fg = c.syntax.func},
     javascriptTSProperty = {fg = c.syntax.func},
     regexTSStringEscape = {fg = c.syntax.keyword},
@@ -432,7 +432,26 @@ function M.setup(config)
 
     -- ALE
     ALEWarningSign = {fg = c.warning},
-    ALEErrorSign = {fg = c.error}
+    ALEErrorSign = {fg = c.error},
+
+    -- Barbar
+    BufferCurrent = {bg = c.bg, fg = c.fg},
+    BufferCurrentIndex = {bg = c.bg, fg = c.fg},
+    BufferCurrentMod = {bg = c.bg, fg = c.warning},
+    BufferCurrentSign = {bg = c.bg, fg = c.info},
+    BufferCurrentTarget = {bg = c.bg, fg = c.fg_light},
+    BufferVisible = {bg = c.bg2, fg = c.fg_dark},
+    BufferVisibleIndex = {bg = c.bg2, fg = c.red},
+    BufferVisibleMod = {bg = c.bg2, fg = c.warning},
+    BufferVisibleSign = {bg = c.bg2, fg = c.info},
+    BufferVisibleTarget = {bg = c.bg2, fg = c.red},
+    BufferInactive = {bg = c.bg2, fg = c.fg_dark},
+    BufferInactiveIndex = {bg = c.bg2, fg = c.fg_light},
+    BufferInactiveMod = {bg = c.bg2, fg = util.darken(c.warning, 0.7)},
+    BufferInactiveSign = {bg = c.bg2, fg = util.darken(c.fg_dark, 0.4, c.bg2)},
+    BufferInactiveTarget = {bg = c.bg2, fg = c.red},
+    BufferTabpages = {bg = c.bg2, fg = c.none},
+    BufferTabpage = {bg = c.bg2, fg = c.border_highlight}
   }
 
   if config.hideInactiveStatusline then


### PR DESCRIPTION
### Changes
- `javascriptTSStringRegex` foreground color fixed
- [barbar.nvim](https://github.com/romgrk/barbar.nvim) plugin support
- Update log inside `CHANGELOG.md`
- [README#plugin-support](https://github.com/projekt0n/github-nvim-theme#plugin-support) updated

### Previews
##### Dark
![Screenshot_20210730_144029](https://user-images.githubusercontent.com/24286590/127632515-740644dd-a122-4144-a579-0d9fc30d1055.png)

##### Dimmed
![Screenshot_20210730_144053](https://user-images.githubusercontent.com/24286590/127632536-3932c6e4-d647-4163-9874-46d06e9fef00.png)

##### Light
![Screenshot_20210730_143946](https://user-images.githubusercontent.com/24286590/127632545-0a75e53b-cae4-4198-b781-fa5862e1fef3.png)
