### PR TITLE
feat: `msgAreaStyle` config added for customize message & cmdline 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Area for messages and cmdline with `bold` text highlight #44
 - `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
 - Custom [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) colors (releated to #16)
+- `msgAreaStyle` config added
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ require('lualine').setup {
 | keywordStyle           | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                         |
 | functionStyle          | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
 | variableStyle          | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
+| msgAreaStyle           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                             |
 | transparent            | `false`  | Enable this to disable setting the background color                                                                                                             |
 | hideEndOfBuffer        | `true`   | Enabling this option, will hide filler lines (~) after the end of the buffer                                                                                    |
 | hideInactiveStatusline | `false`  | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -13,6 +13,7 @@ config = {
   keywordStyle = "italic",
   functionStyle = "NONE",
   variableStyle = "NONE",
+  msgAreaStyle = "NONE",
   hideInactiveStatusline = false,
   hideEndOfBuffer = true,
   sidebars = {},

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -42,7 +42,7 @@ function M.setup(config)
     CursorLineNr = {fg = c.cursor_line_nr}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {bg = c.syntax.matchParenBG, fg = c.fg}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")
-    MsgArea = {fg = c.fg, style = "bold"}, -- Area for messages and cmdline
+    MsgArea = {fg = c.fg, style = config.msgAreaStyle}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     MoreMsg = {fg = c.blue}, -- |more-prompt|
     NonText = {fg = c.bg}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.


### PR DESCRIPTION
### Changes
- `msgAreaStyle` config added
- Updated logs inside `CHANGELOG.md`
- config docs added inside `README.md`

### Default config
```lua 
require("github-theme").setup({
  msgAreaStyle = "NONE"
  -- other config
})
```
### Preview

#### default
![image](https://user-images.githubusercontent.com/24286590/130430395-9ae884c9-f315-4562-b3d3-90d5abbaec82.png)

#### bold
![image](https://user-images.githubusercontent.com/24286590/130430553-a34e8a62-74ab-44aa-ac41-0f6f7da0c02d.png)

#### italic
![image](https://user-images.githubusercontent.com/24286590/130431042-705f9817-4576-49ff-94e9-b11113e5809b.png)

check `:help highlight-args` for other options