### PR TITLE
feat: telescope.nvim highlights improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
 - Custom [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) colors (releated to #16)
 - `msgAreaStyle` config added
+- `border` color added in `colors.lua`
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lualine `normal` section background color set blue color #43
 - Kitty window border colors fix #47
 - refactored `lua/github-theme/config.lua` fixed #29
+- telescope.nvim highlights improved
+- use `bg_visiual` color as floating window border
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -135,7 +135,6 @@ function M.setup(config)
       typescript = "#519aba",
       xml = "#e37933",
       yml = "#a074c4"
-
     }
 
   }
@@ -151,6 +150,7 @@ function M.setup(config)
   colors.eob = config.transparent and colors.fg_light or colors.eob
 
   colors.fg_search = colors.none
+  colors.border = colors.bg_visual
   colors.border_highlight = colors.blue
   colors.bg_statusline = colors.blue
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -50,7 +50,7 @@ function M.setup(config)
     NormalNC = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text in non-current windows
     NormalSB = {fg = c.fg, bg = c.bg_sidebar}, -- normal text in non-current windows
     NormalFloat = {fg = c.fg, bg = c.bg_float}, -- Normal text in floating windows.
-    FloatBorder = {fg = c.border_highlight},
+    FloatBorder = {fg = c.boder},
     Pmenu = {bg = c.pmenu.bg, fg = c.fg}, -- Popup menu: normal item.
     PmenuSel = {bg = c.pmenu.select, fg = c.fg}, -- Popup menu: selected item.
     PmenuSbar = {bg = c.pmenu.bg}, -- Popup menu: scrollbar.
@@ -370,7 +370,17 @@ function M.setup(config)
     GitSignsDelete = {fg = c.gitSigns.delete}, -- diff mode: Deleted line |diff.txt|
 
     -- Telescope
-    TelescopeBorder = {fg = c.border_highlight},
+    TelescopeBorder = {fg = c.border},
+    TelescopePromptPrefix = {fg = c.fg},
+    TelescopeMatching = {fg = c.syntax.constant, style = "bold"},
+    TelescopePreviewPipe = {fg = c.brightYellow},
+    TelescopePreviewRead = {fg = c.brightYellow},
+    TelescopePreviewSize = {fg = c.brightGreen},
+    TelescopePreviewUser = {fg = c.brightYellow},
+    TelescopePreviewBlock = {fg = c.brightYellow},
+    TelescopePreviewGroup = {fg = c.brightYellow},
+    TelescopePreviewWrite = {fg = c.brightMagenta},
+    TelescopePreviewSticky = {fg = c.brightCyan},
 
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},


### PR DESCRIPTION
### Changes
- `border` color added in `colors.lua`
- telescope.nvim highlights improved
- use `bg_visiual` color as floating window border
- `CHANGELOG.md` logs updated

### Preview

#### dark
![dark-telecope.nvim](https://imgur.com/MMBjEsu.png)
#### dimmed
![dimmed-telecope.nvim](https://imgur.com/UPJfcIu.png)
#### light
![light-telecope.nvim](https://imgur.com/C89jzcX.png)
