### PR TITLE
Set `NonText` & `EndOfBuffer` color value with `bg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactored `lua/github-theme/config.lua` fixed #29
 - telescope.nvim highlights improved
 - use `bg_visiual` color as floating window border
+- use `bg` and `bg2` colors for `EndOfBuffer` `NoneText` fixed #66
 
 ## [v0.0.1] - 9 Jul 2021
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -141,15 +141,13 @@ function M.setup(config)
 
   }
 
-  util.bg = colors.bg
-  colors.bg = config.transparent and colors.none or colors.bg
-
   -- EndOfBuffer colors are configurable
   colors.sidebar_eob = config.darkSidebar and colors.bg2 or colors.bg
   colors.sidebar_eob = config.hideEndOfBuffer and colors.sidebar_eob or colors.fg_light
-  colors.sidebar_eob = config.transparent and colors.fg_light or colors.sidebar_eob
   colors.eob = config.hideEndOfBuffer and colors.bg or colors.fg_light
-  colors.eob = config.transparent and colors.fg_light or colors.eob
+
+  util.bg = colors.bg
+  colors.bg = config.transparent and colors.none or colors.bg
 
   colors.fg_search = colors.none
   colors.border_highlight = colors.blue

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -45,7 +45,7 @@ function M.setup(config)
     MsgArea = {fg = c.fg, style = config.msgAreaStyle}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     MoreMsg = {fg = c.blue}, -- |more-prompt|
-    NonText = {fg = c.bg}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+    NonText = {fg = c.eof}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
     Normal = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text
     NormalNC = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text in non-current windows
     NormalSB = {fg = c.fg, bg = c.bg_sidebar}, -- normal text in non-current windows


### PR DESCRIPTION
### Changes
- Removed transparent config for `hideEndOfBuffer`.
- define `util.bg` color after `eob` colors assignment.
- Changelog updated
- Assign `eob` value to `NonText` highlight (inside `theme.lua`)
- Fixed #66 

### Preview

#### Before
![eob after](https://user-images.githubusercontent.com/24286590/132984399-90afb7f6-28ad-4ed2-b113-ca9f5a0232f8.png)

#### Patch
![eob before](https://user-images.githubusercontent.com/24286590/132984395-fd9f9e3c-0368-4435-bc44-984d82ff3a02.png)