### PR TITLE
fixes: transparent mode highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #73 fixed
 - #80 fixed
 - #76 fixed
+- `IncSearch` highlight linked with `Search`
+- `Search` highlight enhanced for `transparent` mode
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #76 fixed
 - `IncSearch` highlight linked with `Search`
 - `Search` highlight enhanced for `transparent` mode
+- `LineNr` highlight enhanced for `transparent` mode
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -530,6 +530,8 @@ function M.setup(config)
 
   }
 
+  util.bg = colors.bg
+
   -- lualine colors are configurable
   colors.lualine = {
     normal = {
@@ -552,9 +554,6 @@ function M.setup(config)
   colors.sidebar_eob = config.dark_sidebar and colors.bg2 or colors.bg
   colors.sidebar_eob = config.hide_end_of_buffer and colors.sidebar_eob or colors.fg_light
   colors.eob = config.hide_end_of_buffer and colors.bg or colors.fg_light
-
-  util.bg = colors.bg
-  colors.bg = config.transparent and colors.none or colors.bg
 
   colors.fg_search = colors.none
   colors.border_highlight = colors.blue

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -38,7 +38,7 @@ function M.setup(config)
     SignColumn = {bg = config.transparent and c.none or c.bg, fg = c.fg_gutter}, -- column where |signs| are displayed
     SignColumnSB = {bg = c.bg_sidebar, fg = c.fg_gutter}, -- column where |signs| are displayed
     Substitute = {bg = c.red, fg = c.black}, -- |:substitute| replacement text highlighting
-    LineNr = {fg = c.line_nr}, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
+    LineNr = {fg = config.transparent and c.cursor_line_nr or c.line_nr}, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is set.
     CursorLineNr = {fg = c.cursor_line_nr}, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line.
     MatchParen = {bg = c.syntax.match_paren_bg, fg = c.fg}, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
     ModeMsg = {fg = c.fg, style = "bold"}, -- 'showmode' message (e.g., "-- INSERT -- ")

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -57,8 +57,8 @@ function M.setup(config)
     PmenuThumb = {bg = c.pmenu.sbar}, -- Popup menu: Thumb of the scrollbar.
     Question = {fg = c.blue}, -- |hit-enter| prompt and yes/no questions
     QuickFixLine = {bg = c.bg_visual, style = "bold"}, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
-    Search = {bg = c.bg_search, fg = c.fg_search}, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
-    IncSearch = {bg = c.orange, fg = c.black}, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
+    Search = {bg = config.transparent and c.orange or c.bg_search, fg = config.transparent and c.black or c.fg_search}, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.
+    IncSearch = {link = "Search"}, -- 'incsearch' highlighting; also used for the text replaced with ":s///c"
     SpecialKey = {fg = c.fg_gutter}, -- Unprintable characters: text displayed differently from what it really is.  But not 'listchars' whitespace. |hl-Whitespace|
     SpellBad = {sp = c.error, style = "undercurl"}, -- Word that is not recognized by the spellchecker. |spell| Combined with the highlighting used otherwise.
     SpellCap = {sp = c.warning, style = "undercurl"}, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.


### PR DESCRIPTION
### Fixes
- `IncSearch` highlight linked with `Search`
- `Search` highlight enhanced for `transparent` mode
- `LineNr` highlight enhanced for `transparent` mode

### Preview
#### Before
![image 2](https://user-images.githubusercontent.com/24286590/134484394-cacc8ba1-98e0-48c0-a65d-74cb1be2b9cf.png)


#### Patch
![image 3](https://user-images.githubusercontent.com/24286590/134484411-4a4c5a5f-a377-40ff-81aa-7d7e410c678e.png)

