### PR TITLE
docs: removed `lua` table assignment from `vim` example (related to #…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Search` highlight enhanced for `transparent` mode
 - `LineNr` highlight enhanced for `transparent` mode
 - refactor: `git_signs` & `dev_icons` colors
+- docs: removed `lua` table assignment from `vim` example (related to #89 #77)
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ require('github-theme').setup()
 let g:github_function_style = "italic"
 let g:github_sidebars = ["qf", "vista_kind", "terminal", "packer"]
 
-" Change the "hint" color to the "orange" color, and make the "error" color bright red
-let g:github_colors = [hint = "orange", error = "#ff0000"]
-
 " Load the colorscheme
 colorscheme github_dark
 ```


### PR DESCRIPTION
…89 #77)