### PR TITLE
docs: colors override docs in `vim` config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ require('github-theme').setup()
 let g:github_function_style = "italic"
 let g:github_sidebars = ["qf", "vista_kind", "terminal", "packer"]
 
+" Change the "hint" color to the "orange" color, and make the "error" color bright red
+let g:github_colors = {
+  \ 'hint': 'orange',
+  \ 'error': '#ff0000'
+\ }
+
 " Load the colorscheme
 colorscheme github_dark
 ```


### PR DESCRIPTION
### Related to:
 - #89 
 - #77 