### PR TITLE
fix: NvimTree git highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor: `git_signs` & `dev_icons` colors
 - docs: removed `lua` table assignment from `vim` example (related to #89 #77)
 - Linting inside `tmux.lua`
+- NvimTree git highlight
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -402,9 +402,9 @@ function M.setup(config)
         light_default = "#22863a"
       }),
       change = themes({
-        dark = "#79b8ff",
+        dark = "#e2c08d",
         dimmed = "#daaa3f",
-        light = "#005cc8",
+        light = "#895503",
         dark_default = "#ac8934",
         light_default = "#b08800"
       }),
@@ -428,6 +428,13 @@ function M.setup(config)
         light = "#959da5",
         dark_default = "#484f58",
         light_default = "#959da5"
+      }),
+      renamed = themes({
+        dark = "#73c991",
+        dimmed = "#73c991",
+        light = "#007100",
+        dark_default = "#73c991",
+        light_default = "#007100"
       })
     },
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -397,6 +397,7 @@ function M.setup(config)
     NvimTreeRootFolder = {fg = c.fg_light, style = "bold"},
     NvimTreeGitDirty = {fg = c.git.change},
     NvimTreeGitNew = {fg = c.git.add},
+    NvimTreeGitRenamed = {fg = c.git.renamed},
     NvimTreeGitDeleted = {fg = c.git.delete},
     NvimTreeSpecialFile = {fg = c.yellow, style = "underline"},
     NvimTreeIndentMarker = {fg = c.syntax.comment},


### PR DESCRIPTION
### Preview

#### Before

![nvim_git_before](https://user-images.githubusercontent.com/24286590/135206918-eb1cc181-32bf-4dbe-8b92-c35169fbcae0.png)

#### Patch
![nvim_git_patch](https://user-images.githubusercontent.com/24286590/135206940-15f767dd-058d-4cd2-a55b-01267ff33a05.png)


