### PR TITLE
fix: Overriding colors inside a table using color group

### DIFF
--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -570,7 +570,7 @@ function M.setup(config)
   colors.bg_sidebar = config.transparent and colors.none or colors.bg_sidebar
   colors.bg_float = config.dark_float and colors.bg2 or colors.bg
 
-  util.color_overrides(colors, config)
+  util.color_overrides(colors, config, colors)
 
   return colors
 end

--- a/lua/github-theme/util.lua
+++ b/lua/github-theme/util.lua
@@ -215,14 +215,16 @@ end
 
 ---@param colors ColorScheme
 ---@param config Config
-function util.color_overrides(colors, config)
+function util.color_overrides(colors, config, basic_colors)
   if type(config.colors) == "table" then
     for key, value in pairs(config.colors) do
-      if not colors[key] then error("Color " .. key .. " does not exist") end
+      if not colors[key] then
+        error("Color " .. key .. " does not exist")
+      end
 
       -- Patch: https://github.com/ful1e5/onedark.nvim/issues/6
       if type(colors[key]) == "table" then
-        util.color_overrides(colors[key], {colors = value})
+        util.color_overrides(colors[key], {colors = value}, basic_colors)
       else
         if value:lower() == "none" then
           -- set to none
@@ -232,8 +234,10 @@ function util.color_overrides(colors, config)
           colors[key] = value
         else
           -- another group
-          if not colors[value] then error("Color " .. value .. " does not exist") end
-          colors[key] = colors[value]
+          if not basic_colors[value] then
+            error("Color " .. value .. " does not exist")
+          end
+          colors[key] = basic_colors[value]
         end
       end
     end


### PR DESCRIPTION
## About
This PR is to fix the use of the group colors when trying to override colors that are "two or more"-level deep in the table.
When trying to use group colors on a "two or more"-level deep color returns an error saying that the color doesn't exist, but that's false when trying to use the "green" or "blue" or any of the necessary colors that it's in use on the theme.
It's possible to point out that the iteration over the color table makes the group colors vanish from the table after analyzing the code.

## Implements
This PR implements a `basic_colors` argument for `color_override`. This `basic_color` is a table with the colors that the theme has. So when using a color group to override a color, it will first verify if `basic_color` has it and then use it.