### PR TITLE
[tmux] Update readability for inactive windows in dimmed tmux theme

### DIFF
--- a/extras/tmux/dimmed.tmux
+++ b/extras/tmux/dimmed.tmux
@@ -27,5 +27,5 @@ set -g status-right "#[fg=#1e2228,bg=#1e2228,nobold,nounderscore,noitalics]#[
 setw -g window-status-activity-style "underscore,fg=#adbac7,bg=#1e2228"
 setw -g window-status-separator ""
 setw -g window-status-style "NONE,fg=#22272e,bg=#1e2228"
-setw -g window-status-format "#[fg=#1e2228,bg=#1e2228,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#1e2228,bg=#1e2228,nobold,nounderscore,noitalics]"
+setw -g window-status-format "#[fg=#1e2228,bg=#1e2228,nobold,nounderscore,noitalics]#[fg=#768390,bg=#1e2228,nobold,nounderscore,noitalics] #I  #W #F #[fg=#1e2228,bg=#1e2228,nobold,nounderscore,noitalics]"
 setw -g window-status-current-format "#[fg=#1e2228,bg=#768390,nobold,nounderscore,noitalics]#[fg=#22272e,bg=#768390,bold] #I  #W #F #[fg=#768390,bg=#1e2228,nobold,nounderscore,noitalics]"


### PR DESCRIPTION
Fixes #105.

Added specific foreground and background coloring to the inactive window formatting. I used the same gray color as the background for the active window.

<img width="340" alt="Screen Shot 2021-10-09 at 7 58 38 PM" src="https://user-images.githubusercontent.com/782969/136676749-df5a5bca-2d79-4840-96b6-2bf01130ccd6.png">
