### PR TITLE
missing `'` in vim config (README.md) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - make `CursorLine` and `CursorColumn` background highlight more visible #109
 - `qfLineNr` & `QuickFixLine` colors updated #119
 - LuaDocs: duplicate warning fixed
+- missing `'` in vim config (README.md) fixed #134
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ let g:github_sidebars = ["qf", "vista_kind", "terminal", "packer"]
 
 " Change the "hint" color to the "orange" color, and make the "error" color bright red
 let g:github_colors = {
-  \ 'hint: 'orange',
+  \ 'hint': 'orange',
   \ 'error': '#ff0000'
 \ }
 


### PR DESCRIPTION
- fixed #134