### PR TITLE
enhance: `StatusLine`  foreground color is customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: assign `user_config` value to `vim.g` global variables
 - refactor: global variable prefix store in `key_prefix` variable
 - refactor: pass common config in `extra` module
+- enhance: `StatusLine` foreground & `StatusLineNC` background colors are customizable ( related to #11 )
 
 ### Fixes
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -544,6 +544,8 @@ function M.setup(config)
 
   -- Statusline
   colors.bg_statusline = colors.blue
+  colors.fg_statusline = colors.bg
+  colors.bg_nc_statusline = colors.bg
   colors.fg_nc_statusline = util.darken(colors.fg, 0.5)
 
   -- Search

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -64,8 +64,8 @@ function M.setup(config)
     SpellCap = {sp = c.warning, style = "undercurl"}, -- Word that should start with a capital. |spell| Combined with the highlighting used otherwise.
     SpellLocal = {sp = c.info, style = "undercurl"}, -- Word that is recognized by the spellchecker as one that is used in another region. |spell| Combined with the highlighting used otherwise.
     SpellRare = {sp = c.hint, style = "undercurl"}, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
-    StatusLine = {fg = c.bg, bg = c.bg_statusline}, -- status line of current window
-    StatusLineNC = {fg = c.fg_nc_statusline, bg = c.bg}, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+    StatusLine = {fg = c.fg_statusline, bg = c.bg_statusline}, -- status line of current window
+    StatusLineNC = {fg = c.fg_nc_statusline, bg = c.bg_nc_statusline}, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
     TabLine = {bg = c.bg, fg = c.fg}, -- tab pages line, not active tab page label
     TabLineFill = {bg = c.bg2}, -- tab pages line, where there are no labels
     TabLineSel = {fg = c.pmenu.select, bg = c.blue}, -- tab pages line, active tab page label


### PR DESCRIPTION
##### Related to #11
### color options added inside `colors.lua`
- fg_statusline
- bg_nc_statusline