### PR TITLE
vscode like lspkind highlighting for `nvim-cmp` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor: global variable prefix store in `key_prefix` variable
 - refactor: pass common config in `extra` module
 - enhance: `StatusLine` foreground & `StatusLineNC` background colors are customizable ( related to #11 )
+- feat: vscode like lspkind highlighting inside `nvim-cmp` #137
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LuaDocs: duplicate warning fixed
 - missing `'` in vim config (README.md) fixed #134
 - typo inisde `theme.lua`
+- missing alias fixed inside `colors.lua`
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `qfLineNr` & `QuickFixLine` colors updated #119
 - LuaDocs: duplicate warning fixed
 - missing `'` in vim config (README.md) fixed #134
+- typo inisde `theme.lua`
 
 ## [v0.0.2] - 15 Sep 2021
 

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -4,7 +4,7 @@ local config_module = require("github-theme.config")
 local M = {}
 
 ---@param config github-theme.Config
----@return ColorScheme
+---@return github-theme.ColorScheme
 function M.setup(config)
   config = config or config_module.config
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -485,6 +485,18 @@ function M.setup(config)
     CmpDocumentation = {links = "NormalFloat"},
     CmpDocumentationBorder = {links = "FloatBorder"},
 
+    CmpItemAbbrDeprecated = {fg = c.syntax.comment, style = "strikethrough"},
+    CmpItemAbbrMatch = {fg = c.blue},
+    CmpItemAbbrMatchFuzzy = {link = "CmpItemAbbrMatch"},
+    CmpItemKindVariable = {fg = c.syntax.variable},
+    CmpItemKindInterface = {link = "CmpItemKindVariable"},
+    CmpItemKindText = {link = "CmpItemKindVariable"},
+    CmpItemKindFunction = {fg = c.syntax.func},
+    CmpItemKindMethod = {link = "CmpItemKindFunction"},
+    CmpItemKindKeyword = {fg = c.syntax.keyword},
+    CmpItemKindProperty = {link = "CmpItemKindKeyword"},
+    CmpItemKindUnit = {link = "CmpItemKindKeyword"},
+
     -- nvim-notify
     NotifyERRORTitle = {fg = util.darken(c.error, 0.9)},
     NotifyWARNTitle = {fg = util.darken(c.warning, 0.9)},

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -1,13 +1,13 @@
 local util = require("github-theme.util")
 local colors = require("github-theme.colors")
-local configModule = require("github-theme.config")
+local config_module = require("github-theme.config")
 
 local M = {}
 
 ---@param config github-theme.Config
 ---@return github-theme.Theme
 function M.setup(config)
-  config = config or configModule.config
+  config = config or config_module.config
 
   ---@class github-theme.Theme
   local theme = {}
@@ -45,7 +45,7 @@ function M.setup(config)
     MsgArea = {fg = c.fg, style = config.msg_area_style}, -- Area for messages and cmdline
     -- MsgSeparator= { }, -- Separator for scrolled messages, `msgsep` flag of 'display'
     MoreMsg = {fg = c.blue}, -- |more-prompt|
-    NonText = {fg = c.eof}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
+    NonText = {fg = c.eob}, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
     Normal = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text
     NormalNC = {fg = c.fg, bg = config.transparent and c.none or c.bg}, -- normal text in non-current windows
     NormalSB = {fg = c.fg, bg = c.bg_sidebar}, -- normal text in non-current windows
@@ -267,7 +267,7 @@ function M.setup(config)
     javascriptTSParameter = {fg = c.syntax.param},
     javascriptTSVariable = {fg = c.syntax.variable},
     javascriptTSPunctDelimiter = {fg = c.fg},
-    javascriptTSStringRegex = {fg = c.string},
+    javascriptTSStringRegex = {fg = c.syntax.string},
     javascriptTSConstructor = {fg = c.syntax.func},
     javascriptTSProperty = {fg = c.syntax.func},
     regexTSStringEscape = {fg = c.syntax.keyword},


### PR DESCRIPTION
### Fixes
- typo inisde `theme.lua`
- missing alias fixed inside `colors.lua`
### Features
- vscode like lspkind highlighting inside `nvim-cmp` #137 fixed

#### Feature Preview
#### dark
![image](https://user-images.githubusercontent.com/24286590/144203166-349a42a8-a347-42c1-a214-5323cab217bb.png)
#### dimmed
![image](https://user-images.githubusercontent.com/24286590/144203292-460067e5-9c70-461b-b389-9b0a3d1549a2.png)
#### light
![image](https://user-images.githubusercontent.com/24286590/144203446-9c988858-6fa0-4746-a1cb-9f91c8fd8c1d.png)
#### light_default
![image](https://user-images.githubusercontent.com/24286590/144203561-d4e669e1-8f00-47b7-a0f2-1134ce1e0db0.png)
#### dark_default
![image](https://user-images.githubusercontent.com/24286590/144203036-7ff08079-b08e-45b1-a1cf-325ee43e9e4d.png)
