### PR TITLE
Fix dark foreground color for visited entries in telescope.nvim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+-
+
+### Fixes
+
+- dark foreground color for visited entries in telescope.nvim
+
 ## [v0.0.3] - 09 Dec 2021
 
 ### Added

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -382,14 +382,7 @@ function M.setup(config)
     TelescopeBorder = {fg = c.border},
     TelescopePromptPrefix = {fg = c.fg},
     TelescopeMatching = {fg = c.syntax.constant, style = "bold"},
-    TelescopePreviewPipe = {fg = c.bright_yellow},
-    TelescopePreviewRead = {fg = c.bright_yellow},
-    TelescopePreviewSize = {fg = c.bright_green},
-    TelescopePreviewUser = {fg = c.bright_yellow},
-    TelescopePreviewBlock = {fg = c.bright_yellow},
-    TelescopePreviewGroup = {fg = c.bright_yellow},
-    TelescopePreviewWrite = {fg = c.bright_magenta},
-    TelescopePreviewSticky = {fg = c.bright_cyan},
+    TelescopeMultiSelection = {fg = c.syntax.comment},
 
     -- NvimTree
     NvimTreeNormal = {fg = c.fg_light, bg = c.bg_sidebar},


### PR DESCRIPTION
### Other Changes
- custom highlights are removed from the `telescope.nvim`

### Before
![image](https://user-images.githubusercontent.com/24286590/145563110-124c6743-ba63-42c5-b28d-dff473129bfb.png)

### Patch
![image](https://user-images.githubusercontent.com/24286590/145563191-8249275b-01ac-42bd-a7fb-1ec2a06fe605.png)
