### PR TITLE
Lualine and StatusLine enhancements, deprecation, and refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dark background color for inactive statusline and lualine
 - Minimal look (`hide_inactive_statusline`) removed from lualine
+- `terminal` highlight added for lualine
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Dark background color for inactive statusline and lualine
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Dark background color for inactive statusline and lualine
+- Minimal look (`hide_inactive_statusline`) removed from lualine
 
 ### Fixes
 

--- a/LUALINE.md
+++ b/LUALINE.md
@@ -1,6 +1,7 @@
 To enable the `github` theme for `Lualine`, simply specify it in your lualine settings:
 
-> Set `lualine` configuration **before** `github-theme`. otherwise, the `hide_inactive_statusline` option won't work.
+> ~Set `lualine` configuration **before** `github-theme`. otherwise, the `hide_inactive_statusline` option won't work.~
+> !!Note!! `hide_inactive_statusline` option is deprecated for lualine b699121 4ab803f
 
 ### packer
 
@@ -10,7 +11,7 @@ use {
   config = function()
     require("lualine").setup {
       options = {
-        theme = "github"
+        theme = "github" -- or "auto"
         -- ... your lualine config
       }
     }
@@ -34,7 +35,7 @@ use {
 lua << EOF
 require('lualine').setup {
   options = {
-    theme = 'github',
+    theme = 'github', -- or "auto"
     -- ... your lualine config
   }
 }
@@ -46,7 +47,7 @@ EOF
 ```lua
 require('lualine').setup {
   options = {
-    theme = 'github',
+    theme = 'github', -- or "auto"
     -- ... your lualine config
   }
 }

--- a/LUALINE.md
+++ b/LUALINE.md
@@ -1,7 +1,7 @@
 To enable the `github` theme for `Lualine`, simply specify it in your lualine settings:
 
-> ~Set `lualine` configuration **before** `github-theme`. otherwise, the `hide_inactive_statusline` option won't work.~
-> !!Note!! `hide_inactive_statusline` option is deprecated for lualine b699121 4ab803f
+Note `hide_inactive_statusline` option is deprecated for lualine
+ref: b699121 4ab803f
 
 ### packer
 

--- a/LUALINE.md
+++ b/LUALINE.md
@@ -56,35 +56,40 @@ require('lualine').setup {
 
 #### dark
 
-![normal](https://imgur.com/jUr5BVk.png)
-![insert](https://imgur.com/g0N8LzF.png)
-![visual](https://imgur.com/MfJmoKn.png)
-![command](https://imgur.com/kpkvWsA.png)
+![normal](https://imgur.com/zBRwlUm.png)
+![insert](https://imgur.com/n5DG48e.png)
+![visual](https://imgur.com/MWQXJLD.png)
+![command](https://imgur.com/HGIYVSN.png)
+![terminal](https://imgur.com/pEWjIJ8.png)
 
 #### dark_default
 
-![normal](https://imgur.com/BpoAoRK.png)
-![insert](https://imgur.com/3ZOGEV7.png)
-![visual](https://imgur.com/7NpCZiP.png)
-![command](https://imgur.com/XfiPni9.png)
+![normal](https://imgur.com/yHa1cK1.png)
+![insert](https://imgur.com/mMX2364.png)
+![visual](https://imgur.com/SNwhnph.png)
+![command](https://imgur.com/aLifoAv.png)
+![terminal](https://imgur.com/Q7mG5m8.png)
 
 #### dimmed
 
-![normal](https://imgur.com/vQcPu6L.png)
-![insert](https://imgur.com/FfFPpKB.png)
-![visual](https://imgur.com/pR5j9oE.png)
-![command](https://imgur.com/oKnjGrj.png)
+![normal](https://imgur.com/R800MhA.png)
+![insert](https://imgur.com/42M0X0O.png)
+![visual](https://imgur.com/euIfZtW.png)
+![command](https://imgur.com/E4tzBCD.png)
+![terminal](https://imgur.com/RASnrFw.png)
 
 #### light
 
-![normal](https://imgur.com/KBsO3JX.png)
-![insert](https://imgur.com/yMvEPRR.png)
-![visual](https://imgur.com/30aMdJl.png)
-![command](https://imgur.com/DIgPCoa.png)
+![normal](https://imgur.com/om8f3S5.png)
+![insert](https://imgur.com/qawZ4G6.png)
+![visual](https://imgur.com/3j3ThxU.png)
+![command](https://imgur.com/ItcANVN.png)
+![terminal](https://imgur.com/8SgNyIU.png)
 
 #### light_default
 
-![normal](https://imgur.com/qzXLS8f.png)
-![insert](https://imgur.com/AWTAIXy.png)
-![visual](https://imgur.com/5rfuCuA.png)
-![command](https://imgur.com/CEREFqn.png)
+![normal](https://imgur.com/lwTCVXc.png)
+![insert](https://imgur.com/zh9uPGS.png)
+![visual](https://imgur.com/e3xYvfu.png)
+![command](https://imgur.com/TrjrA3i.png)
+![terminal](https://imgur.com/7ukHRhL.png)

--- a/README.md
+++ b/README.md
@@ -81,21 +81,21 @@ require('github-theme').setup()
 
 ## Configuration
 
-| Option                   | Default  | Description                                                                                                                                                     |
-| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| theme_style              | `dark`   | Set theme variant (options: `dark`/`dark_default`/`dimmed`/`light`/`light_default`)                                                                             |
-| comment_style            | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                                         |
-| keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                                         |
-| function_style           | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                                        |
-| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                                        |
-| msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                                             |
-| transparent              | `false`  | Enable this to disable setting the background color                                                                                                             |
-| hide_end_of_buffer       | `true`   | Enabling this option, will hide filler lines (~) after the end of the buffer                                                                                    |
-| hide_inactive_statusline | `true`   | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine** and **LuaLine**. |
-| sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                                      |
-| dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                                    |
-| dark_float               | `false`  | Float windows like the lsp diagnostics windows get a darker background.                                                                                         |
-| colors                   | `{}`     | You can override specific color groups to use other groups or a hex color                                                                                       |
+| Option                   | Default  | Description                                                                                                                                     |
+| ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| theme_style              | `dark`   | Set theme variant (options: `dark`/`dark_default`/`dimmed`/`light`/`light_default`)                                                             |
+| comment_style            | `italic` | Highlight style for comments (check `:help highlight-args` for options)                                                                         |
+| keyword_style            | `italic` | Highlight style for keywords (check `:help highlight-args` for options)                                                                         |
+| function_style           | `NONE`   | Highlight style for functions (check `:help highlight-args` for options)                                                                        |
+| variable_style           | `NONE`   | Highlight style for variables and identifiers (check `:help highlight-args` for options)                                                        |
+| msg_area_style           | `NONE`   | Highlight style for messages and cmdline (check `:help highlight-args` for options)                                                             |
+| transparent              | `false`  | Enable this to disable setting the background color                                                                                             |
+| hide_end_of_buffer       | `true`   | Enabling this option, will hide filler lines (~) after the end of the buffer                                                                    |
+| hide_inactive_statusline | `true`   | Enabling this option, will hide inactive statuslines and replace them with a thin border instead. Should work with the standard **StatusLine**. |
+| sidebars                 | `{}`     | Set a darker background on sidebar-like windows. For example: `{"qf", "vista_kind", "terminal", "packer"}`                                      |
+| dark_sidebar             | `true`   | Sidebar like windows like `NvimTree` get a darker background                                                                                    |
+| dark_float               | `false`  | Float windows like the lsp diagnostics windows get a darker background.                                                                         |
+| colors                   | `{}`     | You can override specific color groups to use other groups or a hex color                                                                       |
 
 ```vim
 " Example config in VimScript

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -597,6 +597,7 @@ function M.setup(config)
     command = tint_lualine_group(colors.bright_magenta),
     visual = tint_lualine_group(colors.yellow),
     replace = tint_lualine_group(colors.red),
+    terminal = tint_lualine_group(colors.orange),
     inactive = {
       a = {bg = colors.bg_nc_statusline, fg = colors.fg_nc_statusline},
       b = {bg = colors.bg_nc_statusline, fg = colors.fg_nc_statusline},

--- a/lua/github-theme/colors.lua
+++ b/lua/github-theme/colors.lua
@@ -545,8 +545,8 @@ function M.setup(config)
   -- Statusline
   colors.bg_statusline = colors.blue
   colors.fg_statusline = colors.bg
-  colors.bg_nc_statusline = colors.bg
-  colors.fg_nc_statusline = util.darken(colors.fg, 0.5)
+  colors.bg_nc_statusline = colors.bg2
+  colors.fg_nc_statusline = util.darken(colors.fg, 0.3)
 
   -- Search
   colors.fg_search = colors.none
@@ -566,7 +566,7 @@ function M.setup(config)
   colors.bg_sidebar = config.transparent and colors.none or colors.bg_sidebar
   colors.bg_float = config.dark_float and colors.bg2 or colors.bg
 
-  -- lualine
+  -- Lualine
 
   --- create lualine group colors for github-theme
   ---@param color string
@@ -598,9 +598,9 @@ function M.setup(config)
     visual = tint_lualine_group(colors.yellow),
     replace = tint_lualine_group(colors.red),
     inactive = {
-      a = {bg = colors.bg, fg = colors.fg_nc_statusline},
-      b = {bg = colors.bg, fg = colors.fg_nc_statusline},
-      c = {bg = colors.bg, fg = colors.fg_nc_statusline}
+      a = {bg = colors.bg_nc_statusline, fg = colors.fg_nc_statusline},
+      b = {bg = colors.bg_nc_statusline, fg = colors.fg_nc_statusline},
+      c = {bg = colors.bg_nc_statusline, fg = colors.fg_nc_statusline}
     }
   }
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -550,24 +550,19 @@ function M.setup(config)
   theme.defer = {}
 
   if config.hide_inactive_statusline then
-    local inactive = {style = "underline", bg = c.bg, fg = c.bg, sp = c.bg_visual}
+    local inactive
 
     -- StatusLine
+    inactive = {style = "underline", bg = c.bg, fg = c.bg, sp = c.bg_visual}
     theme.base.StatusLineNC = inactive
 
+    -- LuaLine
     if vim.o.statusline ~= nil and string.find(vim.o.statusline, "lualine") then
       -- Fix VertSplit & StatusLine crossover when lualine is active
       -- https://github.com/hoob3rt/lualine.nvim/issues/274
-      theme.base.StatusLine = {bg = c.bg}
-
-      -- LuaLine
-      for _, section in pairs({"a", "b", "c"}) do
-        theme.defer["lualine_" .. section .. "_inactive"] = inactive
-      end
-
-      -- Fix inactive tab highlights
-      -- https://github.com/projekt0n/github-nvim-theme/issues/133
-      theme.defer.lualine_tabs_active_0_no_mode = {fg = c.blue, bg = c.bg}
+      inactive = {bg = c.bg2}
+      theme.base.StatusLine = inactive
+      theme.base.StatusLineNC = inactive
     end
   end
 


### PR DESCRIPTION
##### Changes related to #97 #147 

# :warning: Deprecation :warning: 
- Minimal look (`hide_inactive_statusline`) removed from lualine

### Added
- `terminal` highlight added for lualine

### Refactor
- Dark background color for inactive statusline with lualine plugin
