### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: plugin support [nvim-treesitter/nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) fixed #184
 - terminal-theme: foot theme added #183
 - Added `NvimTreeOpenedeFile` highlight
+- feat: plugin support [echasnovski/mini.nvim](https://github.com/echasnovski/mini.nvim)
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ require("github-theme").setup({
   [lsp-trouble.nvim](https://github.com/folke/lsp-trouble.nvim),
   [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim),
   [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim),
+  [mini.nvim](https://github.com/echasnovski/mini.nvim),
   [neogit](https://github.com/TimUntersberger/neogit),
   [nvim-bufferline.lua](https://github.com/akinsho/nvim-bufferline.lua),
   [nvim-cmp](https://github.com/hrsh7th/nvim-cmp),

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -558,10 +558,63 @@ theme.setup = function(cfg)
 
     -- nvim-treesitter-context
     TreesitterContext = { bg = vim.o.background == 'light' and util.lighten(c.blue, 0.9) or util.darken(c.blue, 0.2) },
+
+    -- mini.nvim
+    MiniCompletionActiveParameter = { style = Styles.Underline },
+
+    MiniCursorword = { bg = c.lsp.ref_txt },
+    MiniCursorwordCurrent = { bg = c.lsp.ref_txt },
+
+    MiniIndentscopeSymbol = { link = 'Delimiter' },
+    MiniIndentscopePrefix = { style = Styles.NoCombine }, -- Make it invisible
+
+    MiniJump = { link = 'SpellRare' },
+
+    MiniJump2dSpot = { fg = vim.o.background == 'light' and c.bright_red or c.magenta, style = Styles.Bold },
+
+    MiniStarterCurrent = { style = Styles.NoCombine },
+    MiniStarterFooter = { fg = c.bright_white, style = Styles.Italic },
+    MiniStarterHeader = { fg = c.blue },
+    MiniStarterInactive = { link = 'Comment' },
+    MiniStarterItem = { link = 'Normal' },
+    MiniStarterItemBullet = { fg = c.border },
+    MiniStarterItemPrefix = { fg = c.warning },
+    MiniStarterSection = { link = 'Special' },
+    MiniStarterQuery = { fg = c.info },
+
+    MiniStatuslineDevinfo = { fg = c.fg, bg = c.bg_highlight },
+    MiniStatuslineFileinfo = { fg = c.fg, bg = c.bg_highlight },
+    MiniStatuslineFilename = { fg = util.darken(c.fg, 0.5), bg = c.bg },
+    MiniStatuslineInactive = { bg = c.bg2, fg = util.darken(c.fg, 0.3) },
+    MiniStatuslineModeCommand = { fg = c.bg, bg = c.bright_magenta, style = Styles.Bold },
+    MiniStatuslineModeInsert = { fg = c.bg, bg = c.green, style = Styles.Bold },
+    MiniStatuslineModeNormal = { fg = c.bg, bg = c.blue, style = Styles.Bold },
+    MiniStatuslineModeOther = { fg = c.bg, bg = c.orange, style = Styles.Bold },
+    MiniStatuslineModeReplace = { fg = c.bg, bg = c.red, style = Styles.Bold },
+    MiniStatuslineModeVisual = { fg = c.bg, bg = c.yellow, style = Styles.Bold },
+
+    MiniSurround = { link = 'IncSearch' },
+
+    MiniTablineCurrent = { fg = c.pmenu.bg, bg = util.darken(c.bright_blue, 0.75), style = Styles.Bold },
+    MiniTablineFill = { link = 'TabLineFill' },
+    MiniTablineHidden = { fg = c.fg, bg = c.bg },
+    MiniTablineModifiedCurrent = { fg = util.darken(c.bright_blue, 0.75), bg = c.pmenu.bg, style = Styles.Bold },
+    MiniTablineModifiedHidden = { fg = c.bg, bg = c.fg },
+    MiniTablineModifiedVisible = { fg = util.darken(c.bright_blue, 0.5), bg = c.pmenu.bg },
+    MiniTablineTabpagesection = { fg = c.none, bg = c.bg_search, style = Styles.Bold },
+    MiniTablineVisible = { fg = c.pmenu.bg, bg = util.darken(c.bright_blue, 0.5) },
+
+    MiniTestEmphasis = { style = Styles.Bold },
+    MiniTestFail = { fg = c.red, style = Styles.Bold },
+    MiniTestPass = { fg = c.green, style = Styles.Bold },
+
+    MiniTrailspace = { bg = c.red },
   }
 
   if cfg.hide_inactive_statusline then
-    hi.base.StatusLineNC = { fg = c.bg, bg = c.bg, sp = c.bg_visual, style = Styles.Underline }
+    local inactive = { fg = c.bg, bg = c.bg, sp = c.bg_visual, style = Styles.Underline }
+    hi.base.StatusLineNC = inactive
+    hi.plugins.MiniStatuslineInactive = inactive
   end
 
   return hi


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from highlight groups to which 'mini.nvim' makes links by default or from analogous plugins.

Differences from default linked groups:
- 'mini.cursorword' is based on 'Illuminate'.
- 'mini.jump2d' is based on 'Hop'.
- 'mini.starter' is based on 'dashboard.lua' and personal choices:
    - `MiniStarterItemBullet` is as border.
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
    - `MiniStarterSection` is chosen to be visible.
- 'mini.statusline' is based on 'lualine/themes/tokyonight.lua' and personal choices:
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` have slightly different background.
    - All `MiniStatuslineMode*` have bold text to increase visibility.
    - `MiniStatuslineModeOther` is chosen from terminal mode.
- 'mini.tabline' is based on explicit 'TabLine*' groups:
    - `MiniTablineCurrent` has bold font to be visually distinctive.
    - `MiniTablineVisible` has slightly darker background than `MiniTablineCurrent`.
    - `MiniTablineTabpagesection` is chosen from `Search` but with bold style to be visible.
    - `MiniTablineModified*` groups have inverted `fg` and `bg` of their counterparts.
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177716835-c4def6c8-0a53-4ea2-be1c-176444f9e1be.mp4

After:

https://user-images.githubusercontent.com/24854248/177716853-d961dd2c-e03f-42cb-8cfd-251f1e61332e.mp4