### PR TITLE
Add support for barbar.nvim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - terminal-theme: foot theme added #183
 - Added `NvimTreeOpenedeFile` highlight
 - feat: plugin support [echasnovski/mini.nvim](https://github.com/echasnovski/mini.nvim)
+- feat: plugin support [romgrk/barbar.nvim](https://github.com/romgrk/barbar.nvim)
 
 ### Fixes
 

--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -453,6 +453,25 @@ theme.setup = function(cfg)
     ALEWarningSign = { fg = c.warning },
     ALEErrorSign = { fg = c.error },
 
+    -- Barbar
+    BufferCurrent = { fg = c.fg },
+    BufferCurrentIndex = { bg = c.bg, fg = c.fg },
+    BufferCurrentMod = { bg = c.bg, fg = c.warning },
+    BufferCurrentSign = { bg = c.bg, fg = c.info },
+    BufferCurrentTarget = { bg = c.bg, fg = c.fg_light },
+    BufferVisible = { bg = c.bg2, fg = c.fg_dark },
+    BufferVisibleIndex = { bg = c.bg2, fg = c.red },
+    BufferVisibleMod = { bg = c.bg2, fg = c.warning },
+    BufferVisibleSign = { bg = c.bg2, fg = c.info },
+    BufferVisibleTarget = { bg = c.bg2, fg = c.red },
+    BufferInactive = { bg = c.bg2, fg = c.fg_dark },
+    BufferInactiveIndex = { bg = c.bg2, fg = c.fg_light },
+    BufferInactiveMod = { bg = c.bg2, fg = util.darken(c.warning, 0.7) },
+    BufferInactiveSign = { bg = c.bg2, fg = util.darken(c.fg_dark, 0.4, c.bg2) },
+    BufferInactiveTarget = { bg = c.bg2, fg = c.red },
+    BufferTabpages = { bg = c.bg2, fg = c.none },
+    BufferTabpageFill = { bg = c.bg2, fg = c.bg_highlight },
+
     -- Compe
     CompeDocumentation = { links = 'NormalFloat' },
     CompeDocumentationBorder = { links = 'FloatBorder' },


### PR DESCRIPTION
I found an old PR, https://github.com/projekt0n/github-nvim-theme/pull/51, that seems to add support for this. It's marked as merged but it's not in the `main` branch. I dropped it back in and updated some things.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/74385/182288177-0c157d3e-ac17-419e-a386-60386546935c.png">

<img width="912" alt="image" src="https://user-images.githubusercontent.com/74385/182288213-295bb294-9b7c-4e10-b15e-aea3a3343558.png">
