### PR TITLE
feat: add highlight for BufferLineBackground

### DIFF
--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -439,7 +439,8 @@ theme.setup = function(cfg)
     healthWarning = { fg = c.warning },
 
     -- BufferLine
-    BufferLineIndicatorSelected = { fg = c.blue },
+    BufferLineIndicatorSelected = { fg = c.syntax.param },
+    BufferLineBackground = { fg = c.syntax.comment },
 
     -- Hop
     -- Deep red color for light themes


### PR DESCRIPTION
Added bufferline support to match the original

ref
https://github.com/primer/github-vscode-theme/blob/main/src/theme.js#L163
https://github.com/primer/primitives/blob/da4ffd338a41bb1f653e096c8b886db4834b3715/data/colors/vars/global_dark.ts#L100
https://github.com/primer/primitives/blob/cb66b57be785d2709acf82b272edf4f9e8243101/data/colors/themes/dark.ts#L56