### PR TITLE
fix: delete custom query file which breaks typescript highlights

### DIFF
--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -1,1 +1,0 @@
-"function" @keyword.function


### PR DESCRIPTION
fixes typescript highlights