### PR TITLE
Add support for indent-blankline.nvim

### DIFF
--- a/lua/github-theme/theme.lua
+++ b/lua/github-theme/theme.lua
@@ -633,6 +633,13 @@ theme.setup = function(cfg)
     MiniTestPass = { fg = c.green, style = Styles.Bold },
 
     MiniTrailspace = { bg = c.red },
+
+    -- indent-blankline.nvim
+    IndentBlanklineChar = { fg = util.darken(c.syntax.comment, 0.2) },
+    IndentBlanklineSpaceChar = { fg = util.darken(c.syntax.comment, 0.2) },
+    IndentBlanklineSpaceCharBlankline = { fg = util.darken(c.syntax.comment, 0.2) },
+    IndentBlanklineContextChar = { fg = c.fg },
+    IndentBlanklineContextStart = { sp = c.fg, underline = true },
   }
 
   if cfg.hide_inactive_statusline then


### PR DESCRIPTION
See discussion here:
https://github.com/projekt0n/github-nvim-theme/issues/201

Test result:
(underline does not work in `github_dark_default` & `github_dark`)
![image](https://user-images.githubusercontent.com/10512841/194807034-32605e9f-1ed3-4d74-9207-ee0f274b1791.png)

![image](https://user-images.githubusercontent.com/10512841/194806927-3a6da32c-2875-40f9-8f38-1e25542d234e.png)
