### PR TITLE
Fix theme load when did_setup false

### DIFF
--- a/lua/github-theme/init.lua
+++ b/lua/github-theme/init.lua
@@ -20,7 +20,7 @@ M.load = function(opts)
   end
 
   if not did_setup then
-    M.setup()
+    M.setup { options = {} }
   end
 
   lock = true


### PR DESCRIPTION
Setup tries to access index opts, and it is nil when did_setup is false, throwing an error. Send empty options table to comply with migration to opts.options.