### PR TITLE
fix: lua function declaration name highlighting

### DIFF
--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -1,0 +1,106 @@
+(function_declaration
+  name: [
+    (dot_index_expression
+      table: [
+        (identifier)
+        ;; some manual recursion (up to 8 fields) because ts queries don't
+        ;; support recursion up to arbitrary depths currently
+        (dot_index_expression
+          table: [
+            (identifier)
+            (dot_index_expression
+              table: [
+                (identifier)
+                (dot_index_expression
+                  table: [
+                    (identifier)
+                    (dot_index_expression
+                      table: [
+                        (identifier)
+                        (dot_index_expression
+                          table: [
+                            (identifier)
+                            (dot_index_expression
+                              table: [
+                                (identifier)
+                                (dot_index_expression
+                                  table: [
+                                    (identifier)
+                                    (dot_index_expression)
+                                  ] @function.namespace
+                                  "." @function.punctuation.delimiter
+                                  field: (identifier) @function.namespace)
+                              ] @function.namespace
+                              "." @function.punctuation.delimiter
+                              field: (identifier) @function.namespace)
+                          ] @function.namespace
+                          "." @function.punctuation.delimiter
+                          field: (identifier) @function.namespace)
+                      ] @function.namespace
+                      "." @function.punctuation.delimiter
+                      field: (identifier) @function.namespace)
+                  ] @function.namespace
+                  "." @function.punctuation.delimiter
+                  field: (identifier) @function.namespace)
+              ] @function.namespace
+              "." @function.punctuation.delimiter
+              field: (identifier) @function.namespace)
+          ] @function.namespace
+          "." @function.punctuation.delimiter
+          field: (identifier) @function.namespace)
+      ] @function.namespace
+      "." @function.punctuation.delimiter
+      field: (identifier) @function)
+
+    (method_index_expression
+      table: [
+        (identifier)
+        ;; some manual recursion (up to 8 fields) because ts queries don't
+        ;; support recursion up to arbitrary depths currently
+        (dot_index_expression
+          table: [
+            (identifier)
+            (dot_index_expression
+              table: [
+                (identifier)
+                (dot_index_expression
+                  table: [
+                    (identifier)
+                    (dot_index_expression
+                      table: [
+                        (identifier)
+                        (dot_index_expression
+                          table: [
+                            (identifier)
+                            (dot_index_expression
+                              table: [
+                                (identifier)
+                                (dot_index_expression
+                                  table: [
+                                    (identifier)
+                                    (dot_index_expression)
+                                  ] @method.namespace
+                                  "." @function.punctuation.delimiter
+                                  field: (identifier) @method.namespace)
+                              ] @method.namespace
+                              "." @function.punctuation.delimiter
+                              field: (identifier) @method.namespace)
+                          ] @method.namespace
+                          "." @function.punctuation.delimiter
+                          field: (identifier) @method.namespace)
+                      ] @method.namespace
+                      "." @function.punctuation.delimiter
+                      field: (identifier) @method.namespace)
+                  ] @method.namespace
+                  "." @function.punctuation.delimiter
+                  field: (identifier) @method.namespace)
+              ] @method.namespace
+              "." @function.punctuation.delimiter
+              field: (identifier) @method.namespace)
+          ] @method.namespace
+          "." @function.punctuation.delimiter
+          field: (identifier) @method.namespace)
+      ] @method.namespace
+      ":" @method.punctuation.delimiter
+      method: (identifier) @method)
+  ])


### PR DESCRIPTION
Within a function declaration, the entire function name should be the same color, regardless of whether it's a method etc., and including any punctuation within. This change introduces new treesitter-capture highlight groups which may each be independently overridden by the user.

Note: in Neovim, groups like `@x.y.z` fallback to `@x` implicitly if `@x.y.z` is not defined.