### PR TITLE
ci: Get and update primer primitives automatically

### DIFF
--- a/.github/workflows/update-colors.yml
+++ b/.github/workflows/update-colors.yml
@@ -4,6 +4,7 @@ env:
   _DEST: '${{ github.workspace }}/lua/github-theme/palette/primitives'
   _JSON_DIR: '${{ github.workspace }}/node_modules/@primer/primitives/dist/json/colors'
   _LICENSE_GLOB: '${{ github.workspace }}/node_modules/@primer/primitives/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]*'
+  _PRIMITIVES_PKGJSON: '${{ github.workspace }}/node_modules/@primer/primitives/package.json'
 
 on:
   workflow_dispatch:
@@ -31,9 +32,15 @@ jobs:
           mkdir -p "$_DEST"
           cd "$_JSON_DIR"
 
+          if jq -e .version "$_PRIMITIVES_PKGJSON"; then
+            version="M._VERSION = vim.json.decode([=[$(jq -e .version "$_PRIMITIVES_PKGJSON")]=], { luanil = { object = false, array = false } })"
+          fi
+
           for file in *.json; do
             cat >"${_DEST_DIR}/${file%.json}.lua" <<EOF
+          -- NOTE: THIS IS AN AUTO-GENERATED FILE. DO NOT EDIT BY-HAND.
           local M = vim.json.decode([=[$(<"$file")]=], { luanil = { object = false, array = false } })
+          ${version-}
           M._LICENSE = [=[$license]=]
           return M
           EOF

--- a/.github/workflows/update-colors.yml
+++ b/.github/workflows/update-colors.yml
@@ -1,7 +1,7 @@
 name: Get/Update Primer Color Primitives
 
 env:
-  _DEST: '${{ github.workspace }}/lua/github-theme/palette/primitives'
+  _DEST_DIR: '${{ github.workspace }}/lua/github-theme/palette/primitives'
   _JSON_DIR: '${{ github.workspace }}/node_modules/@primer/primitives/dist/json/colors'
   _LICENSE_GLOB: '${{ github.workspace }}/node_modules/@primer/primitives/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]*'
   _PRIMITIVES_PKGJSON: '${{ github.workspace }}/node_modules/@primer/primitives/package.json'
@@ -29,7 +29,8 @@ jobs:
           set -u +f
           shopt -s nocaseglob failglob
           license="$(<$_LICENSE_GLOB)"
-          mkdir -p "$_DEST"
+          rm -r "$_DEST_DIR" || :
+          mkdir -p "$_DEST_DIR"
           cd "$_JSON_DIR"
 
           if jq -e .version "$_PRIMITIVES_PKGJSON"; then
@@ -37,11 +38,12 @@ jobs:
           fi
 
           for file in *.json; do
-            cat >"${_DEST_DIR}/${file%.json}.lua" <<EOF
+            cat >|"${_DEST_DIR}/${file%.json}.lua" <<EOF
           -- NOTE: THIS IS AN AUTO-GENERATED FILE. DO NOT EDIT BY-HAND.
           local M = vim.json.decode([=[$(<"$file")]=], { luanil = { object = false, array = false } })
           ${version-}
-          M._LICENSE = [=[$license]=]
+          M._LICENSE = [=[
+          $license]=]
           return M
           EOF
           done

--- a/.github/workflows/update-colors.yml
+++ b/.github/workflows/update-colors.yml
@@ -1,0 +1,48 @@
+name: Get/Update Primer Color Primitives
+
+env:
+  _DEST: '${{ github.workspace }}/lua/github-theme/palette/primitives'
+  _JSON_DIR: '${{ github.workspace }}/node_modules/@primer/primitives/dist/json/colors'
+  _LICENSE_GLOB: '${{ github.workspace }}/node_modules/@primer/primitives/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]*'
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 3x per week (every other day) at 12:40pm Pacific Time
+    cron: '40 19 * * 1,3,5'
+
+jobs:
+  get-colors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        # with:
+        #   cache: npm
+
+      - run: npm i @primer/primitives@latest
+
+      - run: |
+          set -u +f
+          shopt -s nocaseglob failglob
+          license="$(<$_LICENSE_GLOB)"
+          mkdir -p "$_DEST"
+          cd "$_JSON_DIR"
+
+          for file in *.json; do
+            cat >"${_DEST_DIR}/${file%.json}.lua" <<EOF
+          local M = vim.json.decode([=[$(<"$file")]=], { luanil = { object = false, array = false } })
+          M._LICENSE = [=[$license]=]
+          return M
+          EOF
+          done
+
+      - run: make fmt
+
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Update color primitives
+          branch: update-color-primitives
+          delete-branch: true
+          title: Update color primitives

--- a/.github/workflows/update-colors.yml
+++ b/.github/workflows/update-colors.yml
@@ -18,8 +18,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
-        # with:
-        #   cache: npm
+        with:
+          node-version: lts
+          check-latest: true
 
       - run: npm i @primer/primitives@latest
 

--- a/.github/workflows/update-colors.yml
+++ b/.github/workflows/update-colors.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   schedule:
     # 3x per week (every other day) at 12:40pm Pacific Time
-    cron: '40 19 * * 1,3,5'
+    - cron: '40 19 * * 1,3,5'
 
 jobs:
   get-colors:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ doc/tags
 test/plenary
 .repro
 misc
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "github-nvim-theme",
-  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-nvim-theme",
-      "version": "0.0.7",
       "dependencies": {
         "@primer/primitives": "^7.11.10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "github-nvim-theme",
+  "version": "0.0.7",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "github-nvim-theme",
+      "version": "0.0.7",
+      "dependencies": {
+        "@primer/primitives": "^7.11.10"
+      }
+    },
+    "node_modules/@primer/primitives": {
+      "version": "7.11.10",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-7.11.10.tgz",
+      "integrity": "sha512-KwChxyp4qbLojZx5Nz8RUElM9K+ObzZWvzkYEu76TC4qEsqb9wW7n78jyov5WhUh5+qj2Qac1iCsPfeTQG5YBw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "github-nvim-theme",
-  "version": "0.0.7",
   "private": true,
   "dependencies": {
     "@primer/primitives": "^7.11.10"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@primer/primitives": "^7.11.10"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "github-nvim-theme",
+  "version": "0.0.7",
   "private": true,
   "dependencies": {
     "@primer/primitives": "^7.11.10"


### PR DESCRIPTION
Introduce a GitHub workflow which runs on a schedule 3 times per week to pull in all of the ***exact*** color definitions for each theme directly from the `@primer/primitives` npm package. This pr adds a `package.json` file for clarity and for dependency tracking/declarations, as well as a new workflow file which is quite simple and uses npm. The workflow goes something like this:

1. Install the latest version of the `@primer/primitives` npm package in CI
2. Extract the color definition JSON files for each theme
3. Convert each JSON file to Lua, so that they can easily be required
4. Place these new Lua files under the new directory `lua/github-theme/palettes/primitives`
5. Run `make fmt` to format all Lua files
6. Use/run the `peter-evans/create-pull-request@v5` gh action, which will create a pr if there were any updates/changes

These color definitions will live under the new directory `lua/github-theme/palettes/primitives` and may be required from Lua at runtime (e.g. in order to build up specs).

The workflow may also be run manually via `workflow_dispatch`.