### PR TITLE
ci(update-colors): fix typo

### DIFF
--- a/.github/workflows/update-color-primitives.yml
+++ b/.github/workflows/update-color-primitives.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: lts
+          node-version: 'lts/*'
           check-latest: true
 
       - run: npm i @primer/primitives@latest


### PR DESCRIPTION
Fix typo: `lts` --> `lts/*`.

`lts` is an invalid node version alias. See: https://github.com/projekt0n/github-nvim-theme/actions/runs/5072809341

Rename `update-colors.yml` to `update-color-primitives.yml` as the latter is more descriptive.