### PR TITLE
ci(update-colors): install stylua before using it

### DIFF
--- a/.github/workflows/update-color-primitives.yml
+++ b/.github/workflows/update-color-primitives.yml
@@ -48,7 +48,11 @@ jobs:
           EOF
           done
 
-      - run: make fmt
+      - uses: JohnnyMorganz/stylua-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: -f stylua.toml --verify -- '${{ _DEST_DIR }}'
 
       - uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
Problem:  the workflow is failing because `run: make fmt` invokes stylua,
          and stylua is not available within ci by default.

Solution: use the action `JohnnyMorganz/stylua-action@v3` to install and
          invoke stylua instead of just doing `run: make fmt`.

See https://github.com/projekt0n/github-nvim-theme/actions/runs/5094439816/jobs/9158251649#step:6:13