### PR TITLE
fix(cache): wrong .git path

### DIFF
--- a/lua/github-theme/init.lua
+++ b/lua/github-theme/init.lua
@@ -94,7 +94,7 @@ M.setup = function(opts)
   local cached_path = util.join_paths(config.options.compile_path, 'cache')
   local cached = read_file(cached_path)
 
-  local git_path = util.join_paths(debug.getinfo(1).source:sub(2, -23), '.git')
+  local git_path = util.join_paths(debug.getinfo(1).source:sub(2, -27), '.git')
   local git = vim.fn.getftime(git_path)
   local hash = require('github-theme.lib.hash')(opts) .. (git == -1 and git_path or git)
 


### PR DESCRIPTION
Alternative fix to #269

The git path should be `./github-nvim-theme/.git` and not `./github-nvim-theme/lua/.git`

This change should fix the stale cache issue after user update the theme, see the videos below for validation:

# Before

https://github.com/projekt0n/github-nvim-theme/assets/56817415/ef91be3b-5085-47d7-891d-7ab332a36727

# After

https://github.com/projekt0n/github-nvim-theme/assets/56817415/2cc6f117-3418-448c-a59b-6ff12304e891


