### PR TITLE
ci(update-colors): fix update-color-primitives.yml

### DIFF
--- a/.github/workflows/update-color-primitives.yml
+++ b/.github/workflows/update-color-primitives.yml
@@ -15,6 +15,14 @@ on:
 jobs:
   get-colors:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: write
+      issues: write
+      packages: read
+      pull-requests: write
+      statuses: write
+      
     steps:
       - uses: actions/checkout@v3
 
@@ -52,7 +60,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          args: -f stylua.toml --verify -- '${{ env._DEST_DIR }}'
+          args: -f stylua.toml --verify -- ${{ env._DEST_DIR }}
 
       - uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
For whatever reason, the stylua action was not properly stripping the single quotes that are passed within the `args:` (even though this action uses [NodeJS `exec()`](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback) which says that it uses `/bin/sh` on Unix to execute the command-line...go figure). Anyway, the single quotes were removed.

Also, permissions required for the automated pull request to succeed were added.

---

I went through the hassle of making sure that [it actually works](https://github.com/tmillr/github-nvim-theme2/actions/runs/5137664526) this time because I've had the worst luck with this! lol. You can view the generated pr [here](https://github.com/tmillr/github-nvim-theme2/pull/3).

The only other requirement for this to work properly is that the repo or organization needs to be configured to allow pr's from GitHub actions, otherwise the automated pr will not go through. While testing, I found out that this setting is not enabled by default. It can be enabled under either repo or organization settings under the `Actions` tab (if not done so already).