### PR TITLE
readme: update darken.sidebars.enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ require('github-theme').setup({
     darken = {                 -- Darken floating windows and sidebar-like windows
       floats = false,
       sidebars = {
-        enable = true,
+        enabled = true,
         list = {},             -- Apply dark background to specific windows
       },
     },


### PR DESCRIPTION
After 806903c1b66a6b29347871922acd7d830a9d5c6a this setting was renamed from `enable` to `enabled`. Update REAME accordingly.

I just fought with this for a while, wondering why my sidebar (nvim-tree) wasn't being darkened :)