### PR TITLE
fix(syntax-hl): set `nocombine` on Comment

### DIFF
--- a/lua/github-theme/group/syntax.lua
+++ b/lua/github-theme/group/syntax.lua
@@ -32,7 +32,7 @@ function M.get(spec, config)
   -- (1) add Commented style settings in config module
   -- stylua: ignore
   return {
-    Comment        = { fg = syn.comment, style = stl.comments }, -- any comment
+    Comment        = { fg = syn.comment, style = stl.comments, nocombine = true }, -- any comment
     Constant       = { fg = syn.const, style = stl.constants }, -- (preferred) any constant
     String         = { fg = syn.string, style = stl.strings }, -- a string constant: 'this is a string'
     Character      = { link = 'String' }, -- a character constant: 'c', '\n'

--- a/lua/github-theme/lib/compiler.lua
+++ b/lua/github-theme/lib/compiler.lua
@@ -60,6 +60,9 @@ vim.o.background = "%s"
       op.fg = values.fg
       op.sp = values.sp
       op.blend = values.blend
+      if op.nocombine == nil then
+        op.nocombine = values.nocombine
+      end
       table.insert(lines, fmt([[h(0, "%s", %s)]], name, inspect(op)))
     end
   end


### PR DESCRIPTION
For `Comment`, don't inherit style attributes (e.g. bold, italic) from other (e.g. overlayed) hl groups. For example, an inline-comment appearing after a markdown heading in a markdown file (heading highlighting extends to the end of the text line, including comments) can become/display bold due to inheriting style attributes. `nocombine` keeps this from happening.