### PR TITLE
fix(palette): get `canvas` from primitives

### DIFF
--- a/lua/github-theme/_test/util.lua
+++ b/lua/github-theme/_test/util.lua
@@ -1,0 +1,21 @@
+local M = {}
+local api = vim.api
+
+function M.await_VimEnter()
+  if vim.v.vim_did_enter == 0 then
+    local co = assert(coroutine.running(), 'test is not running in coroutine')
+
+    api.nvim_create_autocmd('VimEnter', {
+      pattern = '*',
+      once = true,
+      nested = true,
+      callback = vim.schedule_wrap(function()
+        coroutine.resume(co)
+      end),
+    })
+
+    coroutine.yield()
+  end
+end
+
+return M

--- a/lua/github-theme/palette/github_dark.lua
+++ b/lua/github-theme/palette/github_dark.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.gray[7])
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -42,12 +42,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.gray[7],
-    overlay = scale.gray[9],
-    inset = scale.gray[8],
-    subtle = scale.gray[9],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[9],

--- a/lua/github-theme/palette/github_dark_colorblind.lua
+++ b/lua/github-theme/palette/github_dark_colorblind.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.gray[10])
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -42,12 +42,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.gray[10],
-    overlay = scale.gray[9],
-    inset = scale.black,
-    subtle = scale.gray[9],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[7],

--- a/lua/github-theme/palette/github_dark_dimmed.lua
+++ b/lua/github-theme/palette/github_dark_dimmed.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.gray[10])
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -42,12 +42,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.gray[10],
-    overlay = scale.gray[9],
-    inset = scale.black,
-    subtle = scale.gray[9],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[7],

--- a/lua/github-theme/palette/github_dark_high_contrast.lua
+++ b/lua/github-theme/palette/github_dark_high_contrast.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.gray[10])
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -42,12 +42,7 @@ local palette = {
     on_emphasis = scale.gray[10],
   },
 
-  canvas = {
-    default = scale.gray[10],
-    overlay = scale.gray[9],
-    inset = scale.black,
-    subtle = scale.gray[9],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[4],

--- a/lua/github-theme/palette/github_dark_tritanopia.lua
+++ b/lua/github-theme/palette/github_dark_tritanopia.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.gray[10])
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -42,12 +42,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.gray[10],
-    overlay = scale.gray[9],
-    inset = scale.black,
-    subtle = scale.gray[9],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[7],

--- a/lua/github-theme/palette/github_light.lua
+++ b/lua/github-theme/palette/github_light.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.white)
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -43,12 +43,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.white,
-    overlay = scale.white,
-    inset = scale.gray[1],
-    subtle = scale.gray[1],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[3],

--- a/lua/github-theme/palette/github_light_colorblind.lua
+++ b/lua/github-theme/palette/github_light_colorblind.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.white)
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -43,12 +43,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.white,
-    overlay = scale.white,
-    inset = scale.gray[1],
-    subtle = scale.gray[1],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[3],

--- a/lua/github-theme/palette/github_light_high_contrast.lua
+++ b/lua/github-theme/palette/github_light_high_contrast.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.white)
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -43,12 +43,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.white,
-    overlay = scale.white,
-    inset = scale.white,
-    subtle = scale.gray[2],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[9],

--- a/lua/github-theme/palette/github_light_tritanopia.lua
+++ b/lua/github-theme/palette/github_light_tritanopia.lua
@@ -13,7 +13,7 @@ local scale = primitives.scale
 
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
-C.BG = C(scale.white)
+C.BG = C(assert(primitives.canvas.default))
 
 local function alpha(color, a)
   return color:alpha_blend(a):to_css()
@@ -43,12 +43,7 @@ local palette = {
     on_emphasis = scale.white,
   },
 
-  canvas = {
-    default = scale.white,
-    overlay = scale.white,
-    inset = scale.gray[1],
-    subtle = scale.gray[1],
-  },
+  canvas = primitives.canvas,
 
   border = {
     default = scale.gray[3],

--- a/test/github-theme/smoketest/startup_spec.lua
+++ b/test/github-theme/smoketest/startup_spec.lua
@@ -1,0 +1,33 @@
+local assert = require('luassert')
+local t_util = require('github-theme._test.util')
+
+describe('(smoke test)', function()
+  describe('setting colorscheme during startup', function()
+    it('should not error', function()
+      assert.does_not_error(function()
+        vim.cmd('colorscheme github_dark_dimmed')
+      end)
+
+      assert.is.equal('', vim.v.errmsg or '')
+    end)
+  end)
+
+  describe('setting/switching colorscheme post-startup', function()
+    it('should not error', function()
+      t_util.await_VimEnter()
+
+      for _, cs in ipairs({
+        'default',
+        'github_dark_dimmed',
+        'github_dark_dimmed',
+        'github_light',
+      }) do
+        assert.does_not_error(function()
+          vim.cmd('colorscheme ' .. cs)
+        end)
+
+        assert.is.equal('', vim.v.errmsg or '')
+      end
+    end)
+  end)
+end)


### PR DESCRIPTION
This should also correct any issues with the `Normal` bg being off or incorrect, as this color (i.e. the `Normal` bg, the global bg) ultimately derives from `canvas.default` (found in the palette).

Fixes #298