### PR TITLE
Improve diff highlights

### DIFF
--- a/lua/github-theme/group/modules/diffchar.lua
+++ b/lua/github-theme/group/modules/diffchar.lua
@@ -7,7 +7,7 @@ function M.get(spec, config, opts)
     DiffAdd = { link = 'diffAdded' },
     DiffChange = { link = 'diffChanged' },
     DiffDelete = { link = 'diffRemoved' },
-    DiffText = { fg = spec.fg1, bg = spec.bg2 },
+    DiffText = { fg = 'none', bg = spec.diff.text },
   }
 end
 

--- a/lua/github-theme/group/syntax.lua
+++ b/lua/github-theme/group/syntax.lua
@@ -118,9 +118,9 @@ function M.get(spec, config)
     -- markdownLinkText         = {},
 
     -- Diff filetype (runtime/syntax/diff.vim)
-    diffAdded       = { fg = spec.git.add, bg = spec.diff.add }, -- Added lines ('^+.*' | '^>.*')
+    diffAdded       = { fg = 'none', bg = spec.diff.add }, -- Added lines ('^+.*' | '^>.*')
     diffRemoved     = { fg = spec.git.removed, bg = spec.diff.delete },-- Removed lines ('^-.*' | '^<.*')
-    diffChanged     = { fg = spec.git.changed, bg = spec.diff.change }, -- Changed lines ('^! .*')
+    diffChanged     = { fg = 'none', bg = spec.diff.change }, -- Changed lines ('^! .*')
     diffOldFile     = { fg = spec.diag.warn }, -- Old file that is being diff against
     diffNewFile     = { fg = spec.diag.hint }, -- New file that is being compared to the old file
     diffFile        = { fg = spec.diag.info }, -- The filename of the diff ('diff --git a/readme.md b/readme.md')

--- a/lua/github-theme/palette/github_dark.lua
+++ b/lua/github-theme/palette/github_dark.lua
@@ -188,7 +188,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[6]), 0.15),
     delete = alpha(C(pal.scale.red[6]), 0.15),
     change = alpha(C(pal.scale.yellow[6]), 0.15),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[6]), 0.40),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_dark_colorblind.lua
+++ b/lua/github-theme/palette/github_dark_colorblind.lua
@@ -183,7 +183,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[6]), 0.15),
     delete = alpha(C(pal.scale.red[6]), 0.15),
     change = alpha(C(pal.scale.yellow[6]), 0.15),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[6]), 0.40),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_dark_default.lua
+++ b/lua/github-theme/palette/github_dark_default.lua
@@ -182,7 +182,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[6]), 0.15),
     delete = alpha(C(pal.scale.red[6]), 0.15),
     change = alpha(C(pal.scale.yellow[6]), 0.15),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[6]), 0.40),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_dark_dimmed.lua
+++ b/lua/github-theme/palette/github_dark_dimmed.lua
@@ -183,7 +183,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[6]), 0.15),
     delete = alpha(C(pal.scale.red[6]), 0.15),
     change = alpha(C(pal.scale.yellow[6]), 0.15),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[6]), 0.40),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_dark_high_contrast.lua
+++ b/lua/github-theme/palette/github_dark_high_contrast.lua
@@ -183,7 +183,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[6]), 0.15),
     delete = alpha(C(pal.scale.red[6]), 0.15),
     change = alpha(C(pal.scale.yellow[6]), 0.15),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[6]), 0.40),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_dark_tritanopia.lua
+++ b/lua/github-theme/palette/github_dark_tritanopia.lua
@@ -183,7 +183,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[6]), 0.15),
     delete = alpha(C(pal.scale.red[6]), 0.15),
     change = alpha(C(pal.scale.yellow[6]), 0.15),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[6]), 0.40),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_light.lua
+++ b/lua/github-theme/palette/github_light.lua
@@ -189,7 +189,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[7]), 0.3),
     delete = alpha(C(pal.scale.red[7]), 0.3),
     change = alpha(C(pal.scale.yellow[7]), 0.3),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[7]), 0.50),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_light_colorblind.lua
+++ b/lua/github-theme/palette/github_light_colorblind.lua
@@ -184,7 +184,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[7]), 0.3),
     delete = alpha(C(pal.scale.red[7]), 0.3),
     change = alpha(C(pal.scale.yellow[7]), 0.3),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[7]), 0.50),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_light_default.lua
+++ b/lua/github-theme/palette/github_light_default.lua
@@ -183,7 +183,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[7]), 0.3),
     delete = alpha(C(pal.scale.red[7]), 0.3),
     change = alpha(C(pal.scale.yellow[7]), 0.3),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[7]), 0.50),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_light_high_contrast.lua
+++ b/lua/github-theme/palette/github_light_high_contrast.lua
@@ -184,7 +184,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[2]), 0.3),
     delete = alpha(C(pal.scale.red[2]), 0.3),
     change = alpha(C(pal.scale.yellow[2]), 0.3),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[2]), 0.70),
   }
 
   spec.git = {

--- a/lua/github-theme/palette/github_light_tritanopia.lua
+++ b/lua/github-theme/palette/github_light_tritanopia.lua
@@ -184,7 +184,7 @@ local function generate_spec(pal)
     add    = alpha(C(pal.scale.green[2]), 0.3),
     delete = alpha(C(pal.scale.red[2]), 0.3),
     change = alpha(C(pal.scale.yellow[2]), 0.3),
-    text   = spec.fg0
+    text   = alpha(C(pal.scale.yellow[2]), 0.70),
   }
 
   spec.git = {


### PR DESCRIPTION
Hello! I've been trying out this theme in the past few weeks and have been really enjoying using it. It's probably the most well-rounded and polished theme I've come across. One area I found this theme to be slightly weaker than others is inside diff views. Particularly for the `DiffText` highlight group, it's really quite difficult to see the text within the line that has changed. In addition, the syntax highlighting is not preserved for changed and added code. Having the syntax highlighting preserved makes reading the diff more useful and matches GitHub's own diff style more closely. As well, other popular themes such as Catppuccin and Rose-pine preserve syntax highlighting in their diffs, it seems to be standard.

Below is an example of how the change looks.

### **Before:**
![image](https://github.com/projekt0n/github-nvim-theme/assets/47948089/87c68b04-a088-44e3-a56e-1b77cd003cc8)

### **After:**
![image](https://github.com/projekt0n/github-nvim-theme/assets/47948089/daac40f8-92ee-4a8e-a509-9d6e97d339a2)

I have looked closely at all the different theme variations to make sure this change looks good on them. I am fairly new to contributing to open source, but trying to give it a go more regularly. Please feel free to give any feedback. Thanks