### PR TITLE
ci(primitives): transition to new css primitives

### DIFF
--- a/.github/workflows/csstolua.lua
+++ b/.github/workflows/csstolua.lua
@@ -1,0 +1,23 @@
+local res = {}
+
+for ln in io.lines() do
+  local k, v = ln:match('^%s*%-%-(%w.-)%s*:%s*(.-)%s*;%s*$')
+
+  if k then
+    k = k:gsub('%-+', '_')
+
+    if res[k] then
+      assert(res[k] == v)
+    else
+      res[k] = v
+    end
+  end
+end
+
+io.write('local M = {\n')
+
+for k, v in pairs(res) do
+  io.write(('  [%q] = %q,\n'):format(k, v))
+end
+
+io.write('}\n')

--- a/.github/workflows/update-color-primitives.yml
+++ b/.github/workflows/update-color-primitives.yml
@@ -2,15 +2,16 @@ name: Get/Update Primer Color Primitives
 
 env:
   _DEST_DIR: "${{ github.workspace }}/lua/github-theme/palette/primitives"
-  _JSON_DIR: "${{ github.workspace }}/node_modules/@primer/primitives/dist/json/colors"
+  _SRC_DIR: "${{ github.workspace }}/node_modules/@primer/primitives/dist/internalCss"
   _LICENSE_GLOB: "${{ github.workspace }}/node_modules/@primer/primitives/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]*"
   _PRIMITIVES_PKGJSON: "${{ github.workspace }}/node_modules/@primer/primitives/package.json"
+  _CSSTOLUA: "${{ github.workspace }}/.github/workflows/csstolua.lua"
 
 on:
   workflow_dispatch:
   schedule:
-    # 3x per week (every other day) at 12:40pm Pacific Time
-    - cron: "40 19 * * 1,3,5"
+    # once a week, every Monday at 12:40pm Pacific Time
+    - cron: "40 19 * * 1"
 
 jobs:
   get-colors:
@@ -34,21 +35,22 @@ jobs:
       - run: npm i @primer/primitives@latest
 
       - run: |
-          set -u +f
+          set -eu +f
           shopt -s nocaseglob failglob
           license="$(<$_LICENSE_GLOB)"
           rm -r "$_DEST_DIR" || :
           mkdir -p "$_DEST_DIR"
-          cd "$_JSON_DIR"
+          cd "$_SRC_DIR"
 
           if jq -e .version "$_PRIMITIVES_PKGJSON"; then
             version="M._VERSION = vim.json.decode([=[$(jq -e .version "$_PRIMITIVES_PKGJSON")]=], { luanil = { object = false, array = false } })"
           fi
 
-          for file in *.json; do
-            cat >|"${_DEST_DIR}/${file%.json}.lua" <<EOF
+          for file in *.css; do
+            values="$(nvim -l "$_CSSTOLUA" < "$file")"
+            cat >| "${_DEST_DIR}/${file%.css}.lua" <<EOF
           -- NOTE: THIS IS AN AUTO-GENERATED FILE. DO NOT EDIT BY-HAND.
-          local M = vim.json.decode([=[$(<"$file")]=], { luanil = { object = false, array = false } })
+          ${values}
           ${version-}
           M._LICENSE = [=[
           $license]=]


### PR DESCRIPTION
GitHub no longer distributes primitives in JSON format. Also, the names of the values (CSS variables) have changed. Most of the new names correspond 1-to-1 with one of the old names. Some colors have also changed slightly (e.g. `fg-default`), but otherwise remain mostly the same.

See https://primer.style/foundations/primitives/migrating