### PR TITLE
chore: add `/cache` and `/.cache` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ test/plenary
 .repro
 misc
 node_modules/
+/cache
+/.cache


### PR DESCRIPTION
This is useful when using a local cache folder for development.