### PR TITLE
fix(config): `options.darken.sidebars.enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Configuration Deprecation and Migration
+
+-   Reverted/renamed `options.darken.sidebars.enabled` back to `options.darken.sidebars.enable` (see #343)
+
 ### What's New?
 
 -   Added new highlight groups for mini.nvim (#333 by @echasnovski)
@@ -32,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed #340 and #341 (broken/outdated `overrides` example in docs)
 -   Fixed floats not transparent when `transparent = true` (#337 fixed-by #351)
 -   fix(Color): `Color.from_hsv()` is used for HSL
+-   Fixed sidebar is not darkened when configured to do so (affects neo-tree, etc.) (#306 fixed-by #343)
 
 ## [v1.0.2] - 03 May 2023
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ require('github-theme').setup({
     darken = {                 -- Darken floating windows and sidebar-like windows
       floats = true,
       sidebars = {
-        enabled = true,
+        enable = true,
         list = {},             -- Apply dark background to specific windows
       },
     },

--- a/Usage.md
+++ b/Usage.md
@@ -249,8 +249,8 @@ Another setting is for sidebars, which is configured in the `sidebars` sub-table
 
 #### options.darken.sidebars {table}
 
-The `sidebars` sub table of `darken` contains settings for sidebar-like windows. It has two configurations: `enabled` is used to assign a darker background
-to the listed windows, and `list` specifies the windows to be included in the list.
+The `sidebars` sub table of `darken` contains settings for sidebar-like windows. It has two configurations: `enable` is used to assign a darker background
+to the listed windows, and `list` specifies the windows to be darkened.
 
 Example:
 
@@ -259,7 +259,7 @@ local options = {
   darken = {
     floats = false,
     sidebars = {
-      enabled = true,
+      enable = true,
       list = {'qf', 'netrw'} -- default is {}
     }
   }

--- a/doc/github-nvim-theme.txt
+++ b/doc/github-nvim-theme.txt
@@ -331,9 +331,9 @@ sub-table.
 options.darken.sidebars {table}    *github-nvim-theme-options.darken.sidebars*
 
 The `sidebars` sub table of `darken` contains settings for sidebar-like
-windows. It has two configurations: `enabled` is used to assign a darker
+windows. It has two configurations: `enable` is used to assign a darker
 background to the listed windows, and `list` specifies the windows to be
-included in the list.
+darkened.
 
 Example:
 
@@ -342,7 +342,7 @@ Example:
       darken = {
         floats = false,
         sidebars = {
-          enabled = true,
+          enable = true,
           list = {'qf', 'netrw'} -- default is {}
         }
       }

--- a/lua/github-theme/group/editor.lua
+++ b/lua/github-theme/group/editor.lua
@@ -47,7 +47,7 @@ function M.get(spec, config)
     MoreMsg         = { fg = spec.diag.info, style = 'bold' }, -- |more-prompt|
     NonText         = { fg = spec.bg4 }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., '>' displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
     Normal          = { fg = spec.fg1, bg = trans and 'NONE' or spec.bg1 }, -- normal text
-    NormalSB        = { fg = spec.fg1, bg = trans and 'NONE' or config.darken.sidebars.enabled and spec.bg0 or spec.bg1 }, -- normal text
+    NormalSB        = { fg = spec.fg1, bg = trans and 'NONE' or config.darken.sidebars.enable and spec.bg0 or spec.bg1 }, -- normal text
 
     NormalNC        = { fg = spec.fg1, bg = inactive and spec.bg0 or trans and 'NONE' or spec.bg1 }, -- normal text in non-current windows
 

--- a/lua/github-theme/group/modules/neotree.lua
+++ b/lua/github-theme/group/modules/neotree.lua
@@ -7,7 +7,7 @@ local M = {}
 
 function M.get(spec, config, opts)
   local hide_eof = config.hide_end_of_buffer
-  local dark_sb = config.darken.sidebars
+  local dark_sb = config.darken.sidebars.enable
   local c = spec.palette
 
   local function blend(color, a)

--- a/lua/github-theme/group/modules/nvimtree.lua
+++ b/lua/github-theme/group/modules/nvimtree.lua
@@ -4,7 +4,7 @@ local M = {}
 
 function M.get(spec, config, opts)
   local hide_eof = config.hide_end_of_buffer
-  local dark_sb = config.darken.sidebars
+  local dark_sb = config.darken.sidebars.enable
   local c = spec.palette
 
   -- stylua: ignore

--- a/lua/github-theme/util/deprecation.lua
+++ b/lua/github-theme/util/deprecation.lua
@@ -157,6 +157,16 @@ M.check_deprecation = function(opts)
       ' for more info.'
     )
   end
+
+  if (((opts.options or {}).darken or {}).sidebars or {}).enabled ~= nil then
+    dep.write(
+      '  ',
+      { 'options.darken.sidebars.enabled', 'WarningMsg' },
+      ' has been renamed/reverted back to ',
+      { 'options.darken.sidebars.enable', 'WarningMsg' }
+    )
+  end
+
   M.checked_deprecation = true
 end
 

--- a/test/github-theme/config/darken_spec.lua
+++ b/test/github-theme/config/darken_spec.lua
@@ -8,22 +8,24 @@ end
 
 describe('config > options > darken', function()
   before_each(function()
+    -- Could reset more than just this, but this alone seems to work now that the
+    -- compiler is fixed.
     require('github-theme.config').reset()
   end)
 
   describe('> floats', function()
     for _, variant in ipairs(require('github-theme.palette').themes) do
       -- TODO: see #324
-      local _it = variant:find('high[-_]*contrast') and pending or it
+      local it_or_pending = variant:find('high[-_]*contrast') and pending or it
 
-      _it(('should be enabled by default (%s)'):format(variant), function()
+      it_or_pending(('should be enabled by default (%s)'):format(variant), function()
         require('github-theme').setup()
         vim.cmd.colorscheme({ args = { variant } })
         local normal_float = t_util.get_hl('NormalFloat')
         local normal = t_util.get_hl('Normal')
 
         assert.is_true(require('github-theme.config').options.darken.floats)
-        assert.are.not_equal(normal_float.bg, normal.bg)
+        assert.are.not_equal(normal.bg, normal_float.bg)
         assert(
           C(('#%x'):format(normal_float.bg)):luminance()
             < C(('#%x'):format(normal.bg)):luminance(),
@@ -39,10 +41,48 @@ describe('config > options > darken', function()
         vim.cmd.colorscheme({ args = { variant } })
         local normal_float = t_util.get_hl('NormalFloat')
         local normal = t_util.get_hl('Normal')
-
         assert.is_false(require('github-theme.config').options.darken.floats)
-        assert.are.equal(normal_float.bg, normal.bg)
+        assert.are.equal(normal.bg, normal_float.bg)
       end)
     end
+  end)
+
+  describe('> sidebars', function()
+    describe('> enable', function()
+      for _, variant in ipairs(require('github-theme.palette').themes) do
+        -- TODO: see #324
+        local it_or_pending = variant:find('high[-_]*contrast') and pending or it
+
+        it_or_pending(('should be enabled by default (%s)'):format(variant), function()
+          require('github-theme').setup()
+          vim.cmd.colorscheme({ args = { variant } })
+          local normal_sb = t_util.get_hl('NormalSB')
+          local normal = t_util.get_hl('Normal')
+
+          assert.is_true(require('github-theme.config').options.darken.sidebars.enable)
+          assert.are.not_equal(normal.bg, normal_sb.bg)
+          assert(
+            C(('#%x'):format(normal_sb.bg)):luminance()
+              < C(('#%x'):format(normal.bg)):luminance(),
+            ('expected `bg` of `NormalFloat` (#%x) to be darker than `bg` of `Normal` (#%x)'):format(
+              normal_sb.bg,
+              normal.bg
+            )
+          )
+        end)
+
+        it(('should be disabled when set to `false` (%s)'):format(variant), function()
+          require('github-theme').setup({
+            options = { darken = { sidebars = { enable = false } } },
+          })
+
+          vim.cmd.colorscheme({ args = { variant } })
+          local normal_sb = t_util.get_hl('NormalSB')
+          local normal = t_util.get_hl('Normal')
+          assert.is_false(require('github-theme.config').options.darken.sidebars.enable)
+          assert.are.equal(normal.bg, normal_sb.bg)
+        end)
+      end
+    end)
   end)
 end)


### PR DESCRIPTION
**Problem:** `options.darken.sidebars.enabled` and `options.darken.sidebars.enable` both exist, but it is only one option. The default in `config.lua` is `enable`, but it is referred to as `enabled` as well (both in code and docs). It used to be `enable` but was renamed to `enabled`, so it is technically supposed to be `options.darken.sidebars.enabled` at this time (as of this commit's parent).

**Solution:** Deprecate and revert `options.darken.sidebars.enabled` back to `options.darken.sidebars.enable`. This brings it back in-line with the changelog and runtime deprecation checks. `enable` is also more consistent as this is what is used in other parts of the config (e.g. config for `modules`).

**Problem:** In a couple of places, `options.darken.sidebars` is checked for truthiness. This seems to be a typo of `options.darken.sidebars.enable` which is a boolean (unlike the former, which is a table by default and also documented as a table). Tables are always truthy.

**Solution:** Use `options.darken.sidebars.enable` instead of `options.darken.sidebars` in conditionals.

Reverts: fff3e20e, 806903c1
Fixes: #306