### PR TITLE
feat: change Directory highlight group to be blue

### DIFF
--- a/lua/github-theme/group/editor.lua
+++ b/lua/github-theme/group/editor.lua
@@ -30,7 +30,7 @@ function M.get(spec, config)
     CursorIM        = { link = 'Cursor' }, -- like Cursor, but used when in IME mode |CursorIM|
     CursorColumn    = { link = 'CursorLine' }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
     CursorLine      = { bg = spec.bg3 }, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if foreground (ctermfg OR guifg) is not set.
-    Directory       = { fg = spec.syntax.func }, -- directory names (and other special names in listings)
+    Directory       = { fg = c.blue.base }, -- directory names (and other special names in listings)
     DiffAdd         = { bg = spec.diff.add }, -- diff mode: Added line |diff.txt|
     DiffChange      = { bg = spec.diff.change }, -- diff mode: Changed line |diff.txt|
     DiffDelete      = { bg = spec.diff.delete }, -- diff mode: Deleted line |diff.txt|


### PR DESCRIPTION
This is a small PR, just to make the Directory highlight group blue. Only a suggestion. The reasoning behind this is to match the colour of directories in the light theme on Github:

![image](https://github.com/projekt0n/github-nvim-theme/assets/47948089/e599bd57-e437-40f7-9892-b83e67a1c4f4)

Here is how it looks:

![image](https://github.com/projekt0n/github-nvim-theme/assets/47948089/fd0f0e12-0d5b-4307-91eb-c46a6b47a65a)

I also tried with gray since this is the colour of the directories in Github's dark theme, but it doesn't look quite as good:

![image](https://github.com/projekt0n/github-nvim-theme/assets/47948089/b9cf421b-c8e5-4a06-a492-d9caceb80c6c)

Either way, the existing pink colour seems to be a little out of place, in my opinion at least.