### PR TITLE
fix(config): `options.darken.floats` is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### What's New?
+
+-   Added new highlight groups for mini.nvim (#333 by @echasnovski)
+
+### Changes
+
+-   Clarify `options.transparent` in README (resolves #327)
+-   Renamed function `Color:lumanance()` -> `Color:luminance()` in `Color` lib (typo/misspelling)
+
+### Issues Fix
+
+-   Fixed `punctuation.delimiter` treesitter group nearly invisible (#329 fixed by #331)
+-   Closed #305 (no longer valid, fixed)
+-   Closed #292 (no longer valid, fixed)
+-   fix(config): `options.darken.floats` is not used (#345)
+
 ## [v1.0.2] - 03 May 2023
 
 ### What's New?

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ require('github-theme').setup({
       search = false,
     },
     darken = {                 -- Darken floating windows and sidebar-like windows
-      floats = false,
+      floats = true,
       sidebars = {
         enabled = true,
         list = {},             -- Apply dark background to specific windows

--- a/lua/github-theme/_test/util.lua
+++ b/lua/github-theme/_test/util.lua
@@ -18,4 +18,24 @@ function M.await_VimEnter()
   end
 end
 
+---@param group string
+---@param link? boolean
+---@return vim.api.keyset.hl_info
+function M.get_hl(group, link)
+  return api.nvim_get_hl(0, {
+    name = group,
+    link = not not link,
+    create = false,
+  })
+end
+
+if vim.fn.has('nvim-0.10.0') == false or vim.fn.has('nvim-0.10.0') == 0 then
+  function M.get_hl(group, link)
+    return api.nvim_get_hl(0, {
+      name = group,
+      link = not not link,
+    })
+  end
+end
+
 return M

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -30,7 +30,7 @@ local defaults = {
     search = false,
   },
   darken = {
-    floats = false,
+    floats = true,
     sidebars = {
       enable = true,
       list = {},

--- a/lua/github-theme/group/editor.lua
+++ b/lua/github-theme/group/editor.lua
@@ -62,7 +62,7 @@ function M.get(spec, config)
 
     NormalNC        = { fg = spec.fg1, bg = (inactive and spec.bg0) or (trans and 'NONE') or spec.bg1 }, -- normal text in non-current windows
 
-    NormalFloat     = { fg = spec.fg1, bg = spec.bg0 }, -- Normal text in floating windows.
+    NormalFloat     = { fg = spec.fg1, bg = config.darken.floats and spec.bg0 or spec.bg1 }, -- Normal text in floating windows.
     FloatBorder     = { fg = c.border.default }, -- TODO
     Pmenu           = { fg = spec.fg1, bg = spec.bg0 }, -- Popup menu: normal item.
     PmenuSel        = { bg = spec.sel1 }, -- Popup menu: selected item.

--- a/test/github-theme/config/darken_spec.lua
+++ b/test/github-theme/config/darken_spec.lua
@@ -1,0 +1,49 @@
+local assert = require('luassert')
+local t_util = require('github-theme._test.util')
+local C = require('github-theme.lib.color')
+local api = vim.api
+
+if not api.nvim_get_hl then
+  return
+end
+
+describe('config > options > darken', function()
+  before_each(function()
+    require('github-theme.config').reset()
+  end)
+
+  describe('> floats', function()
+    for _, variant in ipairs(require('github-theme.palette').themes) do
+      -- TODO: see #324
+      local _it = variant:find('high[-_]*contrast') and pending or it
+
+      _it(('should be enabled by default (%s)'):format(variant), function()
+        require('github-theme').setup()
+        vim.cmd.colorscheme({ args = { variant } })
+        local normal_float = t_util.get_hl('NormalFloat')
+        local normal = t_util.get_hl('Normal')
+
+        assert.is_true(require('github-theme.config').options.darken.floats)
+        assert.are.not_equal(normal_float.bg, normal.bg)
+        assert(
+          C(('#%x'):format(normal_float.bg)):luminance()
+            < C(('#%x'):format(normal.bg)):luminance(),
+          ('expected `bg` of `NormalFloat` (#%x) to be darker than `bg` of `Normal` (#%x)'):format(
+            normal_float.bg,
+            normal.bg
+          )
+        )
+      end)
+
+      it(('should be disabled when set to `false` (%s)'):format(variant), function()
+        require('github-theme').setup({ options = { darken = { floats = false } } })
+        vim.cmd.colorscheme({ args = { variant } })
+        local normal_float = t_util.get_hl('NormalFloat')
+        local normal = t_util.get_hl('Normal')
+
+        assert.is_false(require('github-theme.config').options.darken.floats)
+        assert.are.equal(normal_float.bg, normal.bg)
+      end)
+    end
+  end)
+end)


### PR DESCRIPTION
**Problem:** `options.darken.floats` isn't used anywhere and `NormalFloat` is unconditionally set to `spec.bg0` (darker background).

**Solution:** Only set `bg` of `NormalFloat` to `bg0` if `options.darken.floats` is `true`, otherwise, set it to `bg1` (default background).

**Problem:** Floating windows are darkened unconditionally and `options.darken.floats` appears to be documented as being `true` by default (see `options.darken` section of Usage.md), however, the actual default in `config.lua` is `false`. In README.md, the default value is properly documented as being `false`.

**Solution:** Change the default value of `options.darken.floats` to `true`. Update the documented default to `true`. This is not a breaking change because this is currently the default behavior.