### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,407 +2,417 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog], and this project adheres to [Semantic Versioning].
 
 ## [unreleased]
 
+## [v1.1.0] - 23 July 2024
+
+### Highlight Groups
+
+As of neovim `v0.10`, several highlight groups have changed. You may need to update your
+config if you are using or overriding any of these groups. Use `:help
+github-theme.nvim-0.10.0.hlgroups` in neovim for a precise breakdown of the groups
+affected.
+
 ### Configuration Deprecation and Migration
 
--   Reverted/renamed `options.darken.sidebars.enabled` back to `options.darken.sidebars.enable` (see #343)
+-  Reverted/renamed `options.darken.sidebars.enabled` back to `options.darken.sidebars.enable` (see #343)
 
 ### What's New?
 
--   Added new highlight groups for mini.nvim (#333 by @echasnovski)
--   Improved highlight-group overrides (#349)
--   Assigning `false` or an empty table to a highlight group clears it
--   Assigning `false` to groups/specs/palettes clears previous settings from the config store
--   Loading/sourcing colorscheme now causes recompilation if config or overrides changed, even if `setup()` was called before
--   Refactored and improved `Color` lib (LSP types and descriptions, code-dedupe, stricter ctor, etc.) (#352)
--   Added and improved types (LSP) for groups, config, and modules (#354)
--   Highlight gitignore files (contents)
+-  Added new highlight groups for mini.nvim (#333 by @echasnovski)
+-  Improved highlight-group overrides (#349)
+-  Assigning `false` or an empty table to a highlight group clears it
+-  Assigning `false` to groups/specs/palettes clears previous settings from the config store for that category
+-  Loading/sourcing colorscheme now causes recompilation if config or overrides changed, even if `setup()` was called before
+-  Refactored and improved `Color` lib (LSP types and descriptions, code-dedupe, stricter ctor, etc.) (#352)
+-  Added and improved types (LSP) for groups, config, and modules (#354)
+-  Added tests and greatly improved test coverage
+-  The highlighting of `gitignore` files has improved
 
 ### Changes
 
--   Clarify `options.transparent` in README (resolves #327)
--   Renamed function `Color:lumanance()` -> `Color:luminance()` in `Color` lib (typo/misspelling)
--   Upstream renamed group: `@field` -> `@variable.parameter`
--   Upstream added group: `@variable.parameter.builtin`
--   Changed Lua function/method calls to default pinkish color, but left builtin functions untouched (as a different color)
+-  Clarify `options.transparent` in README (resolves #327)
+-  Renamed function `Color:lumanance()` -> `Color:luminance()` in `Color` lib (typo/misspelling)
+-  Changed Lua function/method calls to default pinkish color, but left builtin functions untouched (as a different color)
 
 ### Issues Fix
 
--   Fixed `punctuation.delimiter` treesitter group nearly invisible (#329 fixed-by #331)
--   Closed #305 (no longer valid, fixed)
--   Closed #292 (no longer valid, fixed)
--   fix(config): `options.darken.floats` is not used (#345)
--   fix(compiler): consider entire config when hashing (#350) (related-to #262, #340, #341)
--   fix(compiler): always write hash to fs when compile occurs incl. when `require('github-theme').compile()` is called directly (#350)
--   Fixed #340 and #341 (broken/outdated `overrides` example in docs)
--   Fixed floats not transparent when `transparent = true` (#337 fixed-by #351)
--   fix(Color): `Color.from_hsv()` is used for HSL
--   Fixed sidebar is not darkened when configured to do so (affects neo-tree, etc.) (#306 fixed-by #343)
+-  Fixed `punctuation.delimiter` treesitter group nearly invisible (#329 fixed-by #331)
+-  Closed #305 (no longer valid, fixed)
+-  Closed #292 (no longer valid, fixed)
+-  fix(config): `options.darken.floats` is not used (#345)
+-  fix(compiler): consider entire config when hashing (#350) (related-to #262, #340, #341)
+-  fix(compiler): always write hash to fs when compile occurs incl. when `require('github-theme').compile()` is called directly (#350)
+-  Fixed #340 and #341 (broken/outdated `overrides` example in docs)
+-  Fixed floats not transparent when `transparent = true` (#337 fixed-by #351)
+-  fix(Color): `Color.from_hsv()` is used for HSL
+-  Fixed sidebar is not darkened when configured to do so (affects neo-tree, etc.) (#306 fixed-by #343)
 
 ## [v1.0.2] - 03 May 2023
 
 ### What's New?
 
--   Implement [highlight-blend](https://neovim.io/doc/user/syntax.html#highlight-blend) feature #251
--   Added Rust lifetime highlights #289
--   Reimplemented `*_default` colorschemes.
--   Support `WinSeparator` highlight, introduced in Neovim >= 0.10, replacing `VertSplit`.
+-  Implement [highlight-blend](https://neovim.io/doc/user/syntax.html#highlight-blend) feature #251
+-  Added Rust lifetime highlights #289
+-  Reimplemented `*_default` colorschemes.
+-  Support `WinSeparator` highlight, introduced in Neovim >= 0.10, replacing `VertSplit`.
 
 ### Changes
 
--   chore(ci): use `actions/checkout@v4`
--   fix(ci): update neovim macOS distribution naming
+-  chore(ci): use `actions/checkout@v4`
+-  fix(ci): update neovim macOS distribution naming
 
 ### Issues Fix
 
--   Fixed few regex-based/legacy highlight corrections (fixed #285)
--   Closed #251
--   Fixed bug where the current theme gets compiled multiple times instead of compiling all themes #290
--   Fixed darkened sidebars when disabling `options.sidebars.disabled`
--   Fixes #311
+-  Fixed few regex-based/legacy highlight corrections (fixed #285)
+-  Closed #251
+-  Fixed bug where the current theme gets compiled multiple times instead of compiling all themes #290
+-  Fixed darkened sidebars when disabling `options.sidebars.disabled`
+-  Fixes #311
 
 ## [v1.0.1] - 23 July 2023
 
 ### What's New?
 
--   Included Airline themes Fixed #20
--   CI: Get and update primer primitives automatically #253
--   Support coc-explorer highlights
+-  Included Airline themes Fixed #20
+-  CI: Get and update primer primitives automatically #253
+-  Support coc-explorer highlights
 
 ### Changes
 
--   Enhance Current Statusline and Popup selection with blue tint
--   Enhance [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) plugin highlights
+-  Enhance Current Statusline and Popup selection with blue tint
+-  Enhance [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) plugin highlights
 
 ### Issues Fix
 
--   Fixed Interactive mode in compiled colorscheme
--   #160 closed due to inactivity.
--   #232 fixed with #266
--   #254 fixed
--   #257 fixed
--   #261 fixed
--   #268 fixed
--   #274 fixed
--   #281 fixed
+-  Fixed Interactive mode in compiled colorscheme
+-  #160 closed due to inactivity.
+-  #232 fixed with #266
+-  #254 fixed
+-  #257 fixed
+-  #261 fixed
+-  #268 fixed
+-  #274 fixed
+-  #281 fixed
 
 ## [v1.0.0] - 19 May 2023
 
 ### Deprecation & Breaking Changes
 
--   The Method of setting and loading colorscheme is changed. Refer to `:h github-theme.changelog-10042023`
--   The `config.vim_config` and `config.default` modules are now deprecated.
--   The `config.apply_configuration()` function is also deprecated.
--   The `theme_style` option is removed. Use `:colorscheme` command instead.
--   The module `plugins.lualine` moved to `util.lualine` and `plugins` module removed.
--   Old `util` module deprecated.
+-  The Method of setting and loading colorscheme is changed. Refer to `:h github-theme.changelog-10042023`
+-  The `config.vim_config` and `config.default` modules are now deprecated.
+-  The `config.apply_configuration()` function is also deprecated.
+-  The `theme_style` option is removed. Use `:colorscheme` command instead.
+-  The module `plugins.lualine` moved to `util.lualine` and `plugins` module removed.
+-  Old `util` module deprecated.
 
 ### Configuration Deprecation and Migration
 
--   `msg_area_style` -> Removed.
--   `comment_style` -> `options.styles.comments`
--   `function_style` -> `options.styles.functions`
--   `keyword_style` -> `options.styles.keywords`
--   `variable_style` -> `options.styles.variables`
--   `transparent` -> `options.transparent`
--   `hide_end_of_buffer` -> `options.hide_end_of_buffer`
--   `hide_inactive_statusline` -> `options.hide_nc_statusline`
--   `dark_float` -> `options.darken.floats`
--   `dark_sidebar`-> `options.darken.sidebars.enable`
--   `sidebars`-> `options.darken.sidebars.list`
--   `colors`-> `palettes` or `specs`
--   `overrides` -> `groups`
--   `dev` -> use vim command `:GithubThemeInteractive`
+-  `msg_area_style` -> Removed.
+-  `comment_style` -> `options.styles.comments`
+-  `function_style` -> `options.styles.functions`
+-  `keyword_style` -> `options.styles.keywords`
+-  `variable_style` -> `options.styles.variables`
+-  `transparent` -> `options.transparent`
+-  `hide_end_of_buffer` -> `options.hide_end_of_buffer`
+-  `hide_inactive_statusline` -> `options.hide_nc_statusline`
+-  `dark_float` -> `options.darken.floats`
+-  `dark_sidebar`-> `options.darken.sidebars.enable`
+-  `sidebars`-> `options.darken.sidebars.list`
+-  `colors`-> `palettes` or `specs`
+-  `overrides` -> `groups`
+-  `dev` -> use vim command `:GithubThemeInteractive`
 
 ### New Configuration
 
--   `options.compile_file_suffix` -> Option for setting compiled file suffix.
--   `options.compile_path` -> Option for setting compile files path.
--   `options.dim_inactive` -> Option for setting darker tint to non active buffers.
--   `options.terminal_colors` -> Option for toggling builtin terminal highlights.
--   `options.module_default` -> Option for toggling plugins highlights
--   `options.modules` -> Option for individual plugins related configuration
--   `options.styles.conditionals` -> Style for conditionals
--   `options.styles.constants` -> Style for constants
--   `options.styles.numbers` -> Style for numbers
--   `options.styles.operators` -> Style for operators
--   `options.styles.strings` -> Style for strings
--   `options.styles.types` -> Style for types
--   `options.inverse.match_paren` -> Reverse match parentheses
--   `options.inverse.visual` -> Reverse visual selection
--   `options.inverse.search` -> Reverse search string
+-  `options.compile_file_suffix` -> Option for setting compiled file suffix.
+-  `options.compile_path` -> Option for setting compile files path.
+-  `options.dim_inactive` -> Option for setting darker tint to non active buffers.
+-  `options.terminal_colors` -> Option for toggling builtin terminal highlights.
+-  `options.module_default` -> Option for toggling plugins highlights
+-  `options.modules` -> Option for individual plugins related configuration
+-  `options.styles.conditionals` -> Style for conditionals
+-  `options.styles.constants` -> Style for constants
+-  `options.styles.numbers` -> Style for numbers
+-  `options.styles.operators` -> Style for operators
+-  `options.styles.strings` -> Style for strings
+-  `options.styles.types` -> Style for types
+-  `options.inverse.match_paren` -> Reverse match parentheses
+-  `options.inverse.visual` -> Reverse visual selection
+-  `options.inverse.search` -> Reverse search string
 
 ### What's New?
 
--   Compiling colorscheme for blazingly fast load using `:GithubThemeCompile`
--   Interactive development mode using `:GithubThemeInteractive`
--   `lib.deprecation` - A Deprecation library to print Deprecation Messages.
--   `lib.log` - A logging library to print log Messages.
--   The `config.default` module has been changed to a variable and moved inside the `config` module.
--   Support [Fidget](https://github.com/j-hui/fidget.nvim) plugin highlights #202
--   Support [fzf-lua](https://github.com/ibhagwan/fzf-lua) plugin highlights #221
--   Support [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) plugin highlights #221
--   Support [dap-ui](https://github.com/rcarriga/nvim-dap-ui) plugin highlights #207
--   Support [diffchar.vim](https://github.com/rickhowe/diffchar.vim) plugin highlights #216
+-  Compiling colorscheme for blazingly fast load using `:GithubThemeCompile`
+-  Interactive development mode using `:GithubThemeInteractive`
+-  `lib.deprecation` - A Deprecation library to print Deprecation Messages.
+-  `lib.log` - A logging library to print log Messages.
+-  The `config.default` module has been changed to a variable and moved inside the `config` module.
+-  Support [Fidget](https://github.com/j-hui/fidget.nvim) plugin highlights #202
+-  Support [fzf-lua](https://github.com/ibhagwan/fzf-lua) plugin highlights #221
+-  Support [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) plugin highlights #221
+-  Support [dap-ui](https://github.com/rcarriga/nvim-dap-ui) plugin highlights #207
+-  Support [diffchar.vim](https://github.com/rickhowe/diffchar.vim) plugin highlights #216
 
 ### Issues Fix
 
--   #157 fixed
--   #160 closed due to inactivity.
--   #191 closed due to inactivity.
--   #193 closed with conversation.
--   #201 fixed
--   #209 fixed
--   #213 fixed
--   #218 closed due to inactivity.
--   #225 closed with conversation.
--   #228 fixed
--   #229 closed with conversation.
--   #231 fixed
--   #232 closed due to inactivity.
--   #233 closed with conversation.
--   #235 closed with conversation.
--   #238 fixed
--   #239 fixed
--   #241 fixed
--   #243 fixed
--   #244 fixed
--   #246 fixed
--   #247 fixed
--   #249 fixed
+-  #157 fixed
+-  #160 closed due to inactivity.
+-  #191 closed due to inactivity.
+-  #193 closed with conversation.
+-  #201 fixed
+-  #209 fixed
+-  #213 fixed
+-  #218 closed due to inactivity.
+-  #225 closed with conversation.
+-  #228 fixed
+-  #229 closed with conversation.
+-  #231 fixed
+-  #232 closed due to inactivity.
+-  #233 closed with conversation.
+-  #235 closed with conversation.
+-  #238 fixed
+-  #239 fixed
+-  #241 fixed
+-  #243 fixed
+-  #244 fixed
+-  #246 fixed
+-  #247 fixed
+-  #249 fixed
 
 ## [v0.0.7] - 16 January 2023
 
 ### Changes
 
--   merged: #222
--   Fixed #214 #220 #223 #224
+-  merged: #222
+-  Fixed #214 #220 #223 #224
 
 ## [v0.0.6] - 03 August 2022
 
 ### Changes
 
--   Terminal Themes moved to
+-  Terminal Themes moved to
     [github-theme-contrib](https://github.com/projekt0n/github-theme-contrib)
--   Terminal themes related code removed
+-  Terminal themes related code removed
 
 ### Added
 
--   feat: plugin support [sindrets/diffview.nvim](https://github.com/sindrets/diffview.nvim) fixed #182
--   feat: plugin support [nvim-treesitter/nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) fixed #184
--   terminal-theme: foot theme added #183
--   Added `NvimTreeOpenedeFile` highlight
--   feat: plugin support [echasnovski/mini.nvim](https://github.com/echasnovski/mini.nvim)
--   feat: plugin support [romgrk/barbar.nvim](https://github.com/romgrk/barbar.nvim)
--   docs: Breaking Change logs with `:h github-theme-changelog`
+-  feat: plugin support [sindrets/diffview.nvim](https://github.com/sindrets/diffview.nvim) fixed #182
+-  feat: plugin support [nvim-treesitter/nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) fixed #184
+-  terminal-theme: foot theme added #183
+-  Added `NvimTreeOpenedeFile` highlight
+-  feat: plugin support [echasnovski/mini.nvim](https://github.com/echasnovski/mini.nvim)
+-  feat: plugin support [romgrk/barbar.nvim](https://github.com/romgrk/barbar.nvim)
+-  docs: Breaking Change logs with `:h github-theme-changelog`
 
 ### Fixes
 
--   fixed #175
--   removed `hi clear` command from loading colorscheme fixed #181
--   removed html tags from README.md
--   fixed #189
--   fixed #186
--   fixed #190
--   fixed lsp warnings and types
+-  fixed #175
+-  removed `hi clear` command from loading colorscheme fixed #181
+-  removed html tags from README.md
+-  fixed #189
+-  fixed #186
+-  fixed #190
+-  fixed lsp warnings and types
 
 ## [v0.0.5] - 03 May 2022
 
 ### Added
 
--   refactor: color types moved to `types/palette.lua`
--   chore: terminal colors
--   feat: use native autocmds on nvim >=0.7 ( fixed #168 )
--   chore: tmux theme's extension changed to `.conf` from `.tmux`
--   BREAKING-CHANGE: removed some colors from `colors.lua`
--   refactor: implement highlight override function in `util.load`
--   enhance: `overrides` function is now able to add custom highlight in `dev` mode.
--   docs: about developer mode
--   BREAKING-CHANGE: set lualine theme with `theme="auto"`
--   terminal-theme: Xresources theme added #166
--   chore: unlink 'Visual' highlight from plugin highlights
--   kitty: add cursor foreground color ( fixed #174 )
--   terminal-theme: Windows Terminal theme added #180 @mutecipher
+-  refactor: color types moved to `types/palette.lua`
+-  chore: terminal colors
+-  feat: use native autocmds on nvim >=0.7 ( fixed #168 )
+-  chore: tmux theme's extension changed to `.conf` from `.tmux`
+-  BREAKING-CHANGE: removed some colors from `colors.lua`
+-  refactor: implement highlight override function in `util.load`
+-  enhance: `overrides` function is now able to add custom highlight in `dev` mode.
+-  docs: about developer mode
+-  BREAKING-CHANGE: set lualine theme with `theme="auto"`
+-  terminal-theme: Xresources theme added #166
+-  chore: unlink 'Visual' highlight from plugin highlights
+-  kitty: add cursor foreground color ( fixed #174 )
+-  terminal-theme: Windows Terminal theme added #180 @mutecipher
 
 ### Fixes
 
--   tmp-fix: deleted lua queries #159
--   nvim-dev-icons colors fixed projekt0n/circles.nvim#6
--   make: tmux prefix fixed
--   tmux: set `bg2` as background in 'message-style' fixed #164
--   fixed #163
--   fixed #165
--   lualine docs updated (fixed #167)
--   fixed #177
--   fix: use pcall to clear autocmd silently @xiyaowong #178
--   fix: skip native_autocmds on some neovim0.7 builds
--   fixed #179
+-  tmp-fix: deleted lua queries #159
+-  nvim-dev-icons colors fixed projekt0n/circles.nvim#6
+-  make: tmux prefix fixed
+-  tmux: set `bg2` as background in 'message-style' fixed #164
+-  fixed #163
+-  fixed #165
+-  lualine docs updated (fixed #167)
+-  fixed #177
+-  fix: use pcall to clear autocmd silently @xiyaowong #178
+-  fix: skip native_autocmds on some neovim0.7 builds
+-  fixed #179
 
 ## [v0.0.4] - 11 January 2022
 
 ### Added
 
--   Github Dark ColorBlind(Beta) added 🎉 #96
--   Github Light ColorBlind(Beta) added 🎉 #96
--   Dark background color for inactive statusline and lualine
--   Minimal look (`hide_inactive_statusline`) removed from lualine
--   `terminal` highlight added for lualine
--   Added basic [coc.nvim](https://github.com/neoclide/coc.nvim) highlights #141
--   define global in project `luarc` config file.
--   Removed unnecessary defer function & highlights
--   allow customizing highlight group ful1e5/onedark.nvim#91
--   refactor: Colors moved to `palette` module
--   `types` module initiate
--   proper color docs with `gt.ColorPalette` type
--   Support `ConfigSchema` type with all modules
--   refactor: config module
--   feat: `githooks` init
--   formatter changed `LuaFormatter`-> `StyLua`
--   chore: removed unnecessary module (`hsluv.lua`)
--   feat: luadoc and type added inside `util.lua`
--   feat: TerminalConf type added in `types` module
--   refactor: modules export & typing
--   refactor: terminal themes moved 'extras' -> 'terminal'
--   feat: Apply highlight's style using `types.HighlightStyle` type
--   refactor: color name changed 'term_fg' -> 'fg_term'
--   feat: suggest config in `vim.g` autocompletion
--   feat: reuse common color in palettes
--   docs: team account added in funding
+-  Github Dark ColorBlind(Beta) added 🎉 #96
+-  Github Light ColorBlind(Beta) added 🎉 #96
+-  Dark background color for inactive statusline and lualine
+-  Minimal look (`hide_inactive_statusline`) removed from lualine
+-  `terminal` highlight added for lualine
+-  Added basic [coc.nvim](https://github.com/neoclide/coc.nvim) highlights #141
+-  define global in project `luarc` config file.
+-  Removed unnecessary defer function & highlights
+-  allow customizing highlight group ful1e5/onedark.nvim#91
+-  refactor: Colors moved to `palette` module
+-  `types` module initiate
+-  proper color docs with `gt.ColorPalette` type
+-  Support `ConfigSchema` type with all modules
+-  refactor: config module
+-  feat: `githooks` init
+-  formatter changed `LuaFormatter`-> `StyLua`
+-  chore: removed unnecessary module (`hsluv.lua`)
+-  feat: luadoc and type added inside `util.lua`
+-  feat: TerminalConf type added in `types` module
+-  refactor: modules export & typing
+-  refactor: terminal themes moved 'extras' -> 'terminal'
+-  feat: Apply highlight's style using `types.HighlightStyle` type
+-  refactor: color name changed 'term_fg' -> 'fg_term'
+-  feat: suggest config in `vim.g` autocompletion
+-  feat: reuse common color in palettes
+-  docs: team account added in funding
 
 ### Fixes
 
--   dark foreground color for visited entries in telescope.nvim
--   Fix #144 - Repatch removed hop.nvim highlights
--   Fix #133 - highlights of inactive tabline in lualine plugin
--   inherit `eof` color from `fg_gutter` #150
--   cleanup: _getColor()_ from `util` module
--   fix #156 - highlight added for `GitSignsCurrentLineBlame`
--   refactor: color renamed `lsp.referenceText` -> `lsp.ref_txt`
--   `TabLineSel` highlight link with `PmenuSel`
--   Fixed `iterm` theme generation
--   fix: lualine theme
+-  dark foreground color for visited entries in telescope.nvim
+-  Fix #144 - Repatch removed hop.nvim highlights
+-  Fix #133 - highlights of inactive tabline in lualine plugin
+-  inherit `eof` color from `fg_gutter` #150
+-  cleanup: _getColor()_ from `util` module
+-  fix #156 - highlight added for `GitSignsCurrentLineBlame`
+-  refactor: color renamed `lsp.referenceText` -> `lsp.ref_txt`
+-  `TabLineSel` highlight link with `PmenuSel`
+-  Fixed `iterm` theme generation
+-  fix: lualine theme
 
 ## [v0.0.3] - 09 December 2021
 
 ### Added
 
--   Github `dark_default` theme added #15 #16 #24
--   Github `light_default` theme added #15 #16
--   Make target added for reloading kitty theme with `kitty_dark_default` & `kitty_light_default`
--   Individual themes for `colorscheme` command #68
--   BREAKING-CHANGE: use **snake_case** inside config instead of ~camelCase~
--   `hide_inactive_statusline` default value is `true`
--   `dark_float` default value is `false`
--   feat: vim config support with "vim.g"
--   lualine colors refactored inside `colors.lua` (related to #80)
--   `NvimTreeIndentMarker` highlight is light #74
--   Github's default themes for `tmux`
--   plugin support: nvim-compe, nvim-cmp and nvim-notify
--   set `vim.o.background` while loading individual colorscheme (folke/tokyonight.nvim#102)
--   enhance: assign config default value to `vim.g` variables
--   re-patch: #72
--   BREAKING-CHANGE: `github` deprecated from `colorscheme` command
--   `pmenu.select` color removed
--   pmenu select background color with dynamic blue color
--   BREAKING-CHANGE: terminal colors are renamed
--   feat: set `vim.o.background` with config module (re-patch #60 #116)
--   enhance: support colorschemes with fzf `Colors` command
--   enhance: unlink `NvimTreeGitIgnored` from `Comment`
--   refactor: global variable prefix store in `key_prefix` variable
--   refactor: pass common config in `extra` module
--   enhance: `StatusLine` foreground & `StatusLineNC` background colors are customizable ( related to #11 )
--   feat: vscode like lspkind highlighting inside `nvim-cmp` #137
--   enhance: highlight all lspkind list in `nvim-cmp` #137
--   Link common highlights for `diff` group
+-  Github `dark_default` theme added #15 #16 #24
+-  Github `light_default` theme added #15 #16
+-  Make target added for reloading kitty theme with `kitty_dark_default` & `kitty_light_default`
+-  Individual themes for `colorscheme` command #68
+-  BREAKING-CHANGE: use **snake_case** inside config instead of ~camelCase~
+-  `hide_inactive_statusline` default value is `true`
+-  `dark_float` default value is `false`
+-  feat: vim config support with "vim.g"
+-  lualine colors refactored inside `colors.lua` (related to #80)
+-  `NvimTreeIndentMarker` highlight is light #74
+-  Github's default themes for `tmux`
+-  plugin support: nvim-compe, nvim-cmp and nvim-notify
+-  set `vim.o.background` while loading individual colorscheme (folke/tokyonight.nvim#102)
+-  enhance: assign config default value to `vim.g` variables
+-  re-patch: #72
+-  BREAKING-CHANGE: `github` deprecated from `colorscheme` command
+-  `pmenu.select` color removed
+-  pmenu select background color with dynamic blue color
+-  BREAKING-CHANGE: terminal colors are renamed
+-  feat: set `vim.o.background` with config module (re-patch #60 #116)
+-  enhance: support colorschemes with fzf `Colors` command
+-  enhance: unlink `NvimTreeGitIgnored` from `Comment`
+-  refactor: global variable prefix store in `key_prefix` variable
+-  refactor: pass common config in `extra` module
+-  enhance: `StatusLine` foreground & `StatusLineNC` background colors are customizable ( related to #11 )
+-  feat: vscode like lspkind highlighting inside `nvim-cmp` #137
+-  enhance: highlight all lspkind list in `nvim-cmp` #137
+-  Link common highlights for `diff` group
 
 ### Fixes
 
--   Fixed `diff` highlight colors for `dark_default` & `light_default`
--   Screenshots and docs updated #63 #16
--   #72 fixed
--   #73 fixed
--   #80 fixed
--   #76 fixed
--   `IncSearch` highlight linked with `Search`
--   `Search` highlight enhanced for `transparent` mode
--   `LineNr` highlight enhanced for `transparent` mode
--   refactor: `git_signs` & `dev_icons` colors
--   docs: removed `lua` table assignment from `vim` example (related to #89 #77)
--   Linting inside `tmux.lua`
--   NvimTree git highlight
--   refactor: de-attach 'bg_statusline' color from lualine
--   fix #83: inactive lualine colors
--   enhance: inactive statusline
--   load colorscheme according to `theme_style` config
--   removed `search` colors force assignments from `transparent` mode #113
--   todo highlight foreground color fixed #115
--   make `CursorLine` and `CursorColumn` background highlight more visible #109
--   `qfLineNr` & `QuickFixLine` colors updated #119
--   LuaDocs: duplicate warning fixed
--   missing `'` in vim config (README.md) fixed #134
--   typo inisde `theme.lua`
--   missing alias fixed inside `colors.lua`
--   Fix `vim.o.background` setting in config module
--   Fix assign `user_config` value to `vim.g` global variables
+-  Fixed `diff` highlight colors for `dark_default` & `light_default`
+-  Screenshots and docs updated #63 #16
+-  #72 fixed
+-  #73 fixed
+-  #80 fixed
+-  #76 fixed
+-  `IncSearch` highlight linked with `Search`
+-  `Search` highlight enhanced for `transparent` mode
+-  `LineNr` highlight enhanced for `transparent` mode
+-  refactor: `git_signs` & `dev_icons` colors
+-  docs: removed `lua` table assignment from `vim` example (related to #89 #77)
+-  Linting inside `tmux.lua`
+-  NvimTree git highlight
+-  refactor: de-attach 'bg_statusline' color from lualine
+-  fix #83: inactive lualine colors
+-  enhance: inactive statusline
+-  load colorscheme according to `theme_style` config
+-  removed `search` colors force assignments from `transparent` mode #113
+-  todo highlight foreground color fixed #115
+-  make `CursorLine` and `CursorColumn` background highlight more visible #109
+-  `qfLineNr` & `QuickFixLine` colors updated #119
+-  LuaDocs: duplicate warning fixed
+-  missing `'` in vim config (README.md) fixed #134
+-  typo inisde `theme.lua`
+-  missing alias fixed inside `colors.lua`
+-  Fix `vim.o.background` setting in config module
+-  Fix assign `user_config` value to `vim.g` global variables
 
 ## [v0.0.2] - 15 September 2021
 
 ### Added
 
--   `folded` colors are configurable
--   Plugin Support check #16
--   added iTerm colorscheme #14
--   added Konsole colorscheme #33
--   `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
--   Terminal themes are structured through `extra/init.lua`
--   Area for messages and cmdline with `bold` text highlight #44
--   `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
--   Custom [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) colors (related to #16)
--   `msgAreaStyle` config added
--   `border` color added in `colors.lua`
--   Set `border` colors according to `themeStyle`
+-  `folded` colors are configurable
+-  Plugin Support check #16
+-  added iTerm colorscheme #14
+-  added Konsole colorscheme #33
+-  `github-theme.util.color_overrides` function support "NONE" color (fix related to #36)
+-  Terminal themes are structured through `extra/init.lua`
+-  Area for messages and cmdline with `bold` text highlight #44
+-  `hideEndOfBuffer` options added. Enabling this option, will hide filler lines (~) after the end of the buffer #46
+-  Custom [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) colors (related to #16)
+-  `msgAreaStyle` config added
+-  `border` color added in `colors.lua`
+-  Set `border` colors according to `themeStyle`
 
 ### Fixes
 
--   Kitty themes typo fixed #3
--   Change terminal background color to `bg` #2
--   Fold Bright background fixed #5
--   Added option to customize statusline background with `bg_statusline` #11
--   Lualine `c` section background color get dark color `bg2`
--   illuminate plugin highlights fixed #10
--   Change `commentTSConstant` highlight to `c.syntax.keyword` from `c.syntax.commentConstant`
--   Removed `commentConstant` color
--   lualine `command` background fixed #30
--   Make window-separator(`VertSplit`) highlight bright (related to #16)
--   Removed unnecessary colors from `colors.lua`
--   Enhanced `TabLineSel` is barely readable foreground color fixed #35
--   Enhanced `transparent` mode background color #41
--   Add proper `Description` inside `konsole` theme (bug from #33)
--   Lualine `normal` section background color set blue color #43
--   Kitty window border colors fix #47
--   refactored `lua/github-theme/config.lua` fixed #29
--   telescope.nvim highlights improved
--   use `bg_visiual` color as floating window border
--   use `bg` and `bg2` colors for `EndOfBuffer` `NoneText` fixed #66
+-  Kitty themes typo fixed #3
+-  Change terminal background color to `bg` #2
+-  Fold Bright background fixed #5
+-  Added option to customize statusline background with `bg_statusline` #11
+-  Lualine `c` section background color get dark color `bg2`
+-  illuminate plugin highlights fixed #10
+-  Change `commentTSConstant` highlight to `c.syntax.keyword` from `c.syntax.commentConstant`
+-  Removed `commentConstant` color
+-  lualine `command` background fixed #30
+-  Make window-separator(`VertSplit`) highlight bright (related to #16)
+-  Removed unnecessary colors from `colors.lua`
+-  Enhanced `TabLineSel` is barely readable foreground color fixed #35
+-  Enhanced `transparent` mode background color #41
+-  Add proper `Description` inside `konsole` theme (bug from #33)
+-  Lualine `normal` section background color set blue color #43
+-  Kitty window border colors fix #47
+-  refactored `lua/github-theme/config.lua` fixed #29
+-  telescope.nvim highlights improved
+-  use `bg_visiual` color as floating window border
+-  use `bg` and `bg2` colors for `EndOfBuffer` `NoneText` fixed #66
 
 ## [v0.0.1] - 09 July 2021
 
 ### Added
 
--   Initial release 🎊
+-  Initial release 🎊
 
-[unreleased]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.2...main
-[v1.0.2]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.1...v1.0.0
-[v1.0.1]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.1...v1.0.0
-[v1.0.0]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.0...v0.0.7
-[v0.0.7]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.7...v0.0.6
-[v0.0.6]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.6...v0.0.5
-[v0.0.5]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.5...v0.0.4
-[v0.0.4]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.4...v0.0.3
-[v0.0.3]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.3...v0.0.2
-[v0.0.2]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.2...v0.0.1
+[unreleased]: https://github.com/projekt0n/github-nvim-theme/compare/v1.1.0...main
+[v1.1.0]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.2...v1.1.0
+[v1.0.2]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.1...v1.0.2
+[v1.0.1]: https://github.com/projekt0n/github-nvim-theme/compare/v1.0.0...v1.0.1
+[v1.0.0]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.7...v1.0.0
+[v0.0.7]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.6...v0.0.7
+[v0.0.6]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.5...v0.0.6
+[v0.0.5]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.4...v0.0.5
+[v0.0.4]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.3...v0.0.4
+[v0.0.3]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.2...v0.0.3
+[v0.0.2]: https://github.com/projekt0n/github-nvim-theme/compare/v0.0.1...v0.0.2
 [v0.0.1]: https://github.com/projekt0n/github-nvim-theme/tree/v0.0.1
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html

--- a/doc/gt_changelog.txt
+++ b/doc/gt_changelog.txt
@@ -1,28 +1,156 @@
 *gt_changelog.txt*     Changelogs and breaking changes for GitHub Neovim Theme
 
 ================================================================================
+CHANGELOGS                                              *github-theme.changelog*
 
-CHANGELOGS                                                *github-theme.changelog*
+
+                                               *github-theme.changelog-23072024*
+--------------------------------------------------------------------------------
+23 July, 2024
+
+CONFIGURATION AND API
+
+Highlight-group overrides have received a few small improvements. Assigning
+`false` or an empty table to a highlight group clears it. Assigning `false` to
+`groups`, `specs`, or `palettes` clears previous settings from the config store
+for that category ("previous" meaning earlier in the same `nvim` session).
+
+Setting `options.transparent` to `true` make's neovim's background transparent.
+Floats and sidebars will receive a similar background in this case, regardless
+of any other float/sidebar-specific options set (although overrides may still be
+used). |github-nvim-theme-configuration|
+
+In the |github-nvim-theme-color| lib, the `Color:lumanance()` method has been
+renamed to `Color:luminance()` (corrected typo/misspelling).
+
+                                             *github-theme.nvim-0.10.0.hlgroups*
+HIGHLIGHT GROUPS
+
+As of neovim `v0.10`, several highlight groups have changed. You may need to
+update your config if you are using or overriding any of the groups listed in
+the following sections.
+
+Visit |treesitter-highlight-groups| to see all of the `treesitter` groups
+currently in-use for your version of neovim.
+
+Visit |highlight-groups| and |group-name| to see all of the `standard` groups
+currently in-use for your version of neovim.
+
+                                     *github-theme.nvim-0.10.0.hlgroups-renamed*
+Highlight Groups Renamed ~
+
+  • @conditional                      ->  @keyword.conditional
+  • @debug                            ->  @keyword.debug
+  • @define                           ->  @keyword.directive or @keyword.directive.define
+  • @exception                        ->  @keyword.exception
+  • @field                            ->  @variable.member
+  • @float                            ->  @number.float
+  • @include                          ->  @keyword.import
+  • @method                           ->  @function.method
+  • @method.call                      ->  @function.method.call
+  • @namespace                        ->  @module
+  • @parameter                        ->  @variable.parameter
+  • @preproc                          ->  @keyword.directive
+  • @punctuation.special              ->  @markup.list (markdown lists only; move subitems from `@text.todo`)
+  • @repeat                           ->  @keyword.repeat
+  • @storageclass                     ->  @keyword.storage
+  • @string.regex                     ->  @string.regexp
+  • @string.special                   ->  @markup.link.label (non-url links)
+  • @symbol                           ->  @string.special.symbol
+  • @text.*                           ->  @markup.{strong,italic,link,strikethrough} (with exceptions; see below)
+  • @text.diff.{add,delete,}          ->  @diff.{plus,minus,delta}
+  • @text.literal                     ->  @markup.raw
+  • @text.reference                   ->  @markup.link
+  • @text.title                       ->  @markup.heading
+  • @text.uri                         ->  @markup.link.url (in markup links)
+  • @text.uri                         ->  @string.special.url (outside markup)
+  • @text.{todo,warning,note,danger}  ->  @comment.{todo,warning,note,error}
+
+                                     *github-theme.nvim-0.10.0.hlgroups-removed*
+Highlight Groups Removed ~
+
+  • VertSplit                         ->  use `WinSeparator` instead
+  • @error                            ->  there appears to be no replacement at this time
+
+                                       *github-theme.nvim-0.10.0.hlgroups-added*
+Highlight Groups Added ~
+
+The following is a list of groups which have been added to neovim since the
+beginning of 2024 and does not include any of the groups mentioned in the previous
+sections.
+
+  • @attribute                      attribute annotations (e.g. Python decorators, Rust lifetimes)
+  • @attribute.builtin              builtin annotations (e.g. `@property` in Python)
+
+  • @comment.documentation          comments documenting code
+
+  • @function.call                  function calls
+
+  • @keyword.conditional.ternary    ternary operator (e.g. `?`, `:`)
+  • @keyword.coroutine              keywords related to coroutines (e.g. `go` in Go, `async/await` in Python)
+  • @keyword.function               keywords that define a function (e.g. `func` in Go, `def` in Python)
+  • @keyword.modifier               keywords defining type modifiers (e.g. `const`, `static`, `public`)
+  • @keyword.operator               operators that are English words (e.g. `and`, `or`)
+  • @keyword.return                 keywords like `return` and `yield`
+  • @keyword.type                   keywords defining composite types (e.g. `struct`, `enum`)
+
+  • @markup.heading.1               top-level heading
+  • @markup.heading.2               section heading
+  • @markup.heading.3               subsection heading
+  • @markup.heading.4               and so on
+  • @markup.heading.5               and so forth
+  • @markup.heading.6               six levels ought to be enough for anybody
+  • @markup.list.checked            checked todo-style list markers
+  • @markup.list.unchecked          unchecked todo-style list markers
+  • @markup.math                    math environments (e.g. `$ ... $` in LaTeX)
+  • @markup.quote                   block quotes
+  • @markup.raw.block               literal or verbatim text as a stand-alone block
+
+  • @module.builtin                 built-in modules or namespaces
+
+  • @punctuation.bracket            brackets (e.g. `()`, `{}`, `[]`)
+  • @punctuation.delimiter          delimiters (e.g. `;`, `.`, `,`)
+  • @punctuation.special            special symbols (e.g. `{}` in string interpolation)
+
+  • @string.documentation           string documenting code (e.g. Python docstrings)
+  • @string.special.path            filenames (e.g. those in .gitignore)
+
+  • @tag.attribute                  XML-style tag attributes
+  • @tag.builtin                    XML-style tag names (e.g. HTML5 tags)
+  • @tag.delimiter                  XML-style tag delimiters
+
+  • @type.builtin                   built-in types
+
+  • @variable.builtin               built-in variable names (e.g. `this`, `self`)
+  • @variable.parameter.builtin     special parameters (e.g. `_`, `it`)
+
+  • PmenuMatch                      Popup menu: Matched text in normal item.
+  • PmenuSel                        Popup menu: Matched text in selected item.
+  • SnippetTabstop                  Tabstops in snippets. |vim.snippet|
+  • StatusLineTerm                  Status line of `terminal` window.
+  • StatusLineTermNC                Status line of non-current `terminal` windows.
+  • Added                           added line in a diff (e.g. `diffAdded` links to this)
+  • Changed                         changed line in a diff (e.g. `diffChanged` links to this)
+  • Removed                         removed line in a diff (e.g. `diffRemoved` links to this)
 
 
-                                                 *github-theme.changelog-02122023*
-
-Date: December 02, 2023
+                                               *github-theme.changelog-02122023*
+--------------------------------------------------------------------------------
+December 02, 2023
 
 Reimplemented the `*_default` colorschemes, previously deprecated in the
 |github-theme.changelog-23042023|.
 
-The updated colorscheme list on `:h github-nvim-theme-overview`
+See the updated list of colorschemes at |github-nvim-theme-overview|.
 
 
+                                               *github-theme.changelog-06052023*
+--------------------------------------------------------------------------------
+May 06, 2023
 
-                                                 *github-theme.changelog-06052023*
-
-Date: May 06, 2023
-
-I(ful1e5) removed the `dev` configuration from `setup({...})` and added the
-`vim.g.github_theme_debug` Vim global option for theme debugging. This option
-creates a Lua file in the Neovim cache directory and write debugging logs to
+I (@ful1e5) removed the `dev` configuration from `setup({...})` and added the
+`vim.g.github_theme_debug` vim global option for theme debugging. This option
+creates a Lua file in the neovim cache directory and write debugging logs to
 it.
 
 Previously, the `dev` option was used for debugging and assigning new
@@ -31,10 +159,9 @@ removal of the `dev` option, you can override any highlight without enabling
 any option.
 
 
-
-                                                 *github-theme.changelog-23042023*
-
-Date: April 23, 2023
+                                               *github-theme.changelog-23042023*
+--------------------------------------------------------------------------------
+April 23, 2023
 
 The way to override color variables has been updated. You can now use the
 `specs` table to change colors for a specific colorscheme or for all of them
@@ -48,17 +175,18 @@ or by using the `:colorscheme` vim command.
 The deprecated colorschemes will no longer support any overriding highlight
 groups or color variables. The updated colorscheme list:
 
-- github_dark_default      -> github_dark_high_contrast
-- github_dimmed            -> github_dark_dimmed
-- github_light_default     -> github_light_high_contrast
-- github_dark_tritanopia   -> New!
-- github_light_tritanopia  -> New!
+  • github_dark_default      ->  github_dark_high_contrast
+  • github_dimmed            ->  github_dark_dimmed
+  • github_light_default     ->  github_light_high_contrast
+  • github_dark_tritanopia   ->  New!
+  • github_light_tritanopia  ->  New!
 
 The updated configuration keys are:
-- colors                   -> Use `specs` and `palettes` instead.
-- overrides                -> Use `groups` instead.
 
-Example:
+  • colors                   ->  Use `specs` and `palettes` instead.
+  • overrides                ->  Use `groups` instead.
+
+Example ~
 >lua
   require('github-theme').setup({
     --- ...
@@ -98,43 +226,42 @@ Example:
 <
 
 
-
-                                                *github-theme.changelog-13042023*
-
-Date: April 13, 2023
+                                               *github-theme.changelog-13042023*
+--------------------------------------------------------------------------------
+April 13, 2023
 
 The configuration for defining transparency, darkening windows, floating, and
 hiding elements has been moved to the `options` table.
 
 The updated configuration keys are as follows:
-- transparent              -> options.transparent
-- hide_end_of_buffer       -> options.hide_end_of_buffer
-- hide_inactive_statusline -> options.hide_nc_statusline
-- dark_float               -> options.darken.floats
-- dark_sidebar             -> options.darken.sidebars.enable
-- sidebars                 -> options.darken.sidebars.list
+
+  • transparent               ->  options.transparent
+  • hide_end_of_buffer        ->  options.hide_end_of_buffer
+  • hide_inactive_statusline  ->  options.hide_nc_statusline
+  • dark_float                ->  options.darken.floats
+  • dark_sidebar              ->  options.darken.sidebars.enable
+  • sidebars                  ->  options.darken.sidebars.list
 
 
-
-                                                *github-theme.changelog-12042023*
-
-Date: April 12, 2023
+                                               *github-theme.changelog-12042023*
+--------------------------------------------------------------------------------
+April 12, 2023
 
 The configuration for defining styles has been migrated to `options.styles`.
 As part of this migration, `msg_area_style` has been removed.
 
-Here is the updated config keys:
-- comment_style            -> options.styles.comments
-- function_style           -> options.styles.functions
-- keyword_style            -> options.styles.keywords
-- variable_style           -> options.styles.variables
-- msg_area_style           -> Removed.
+Here are the updated config keys:
+
+  • comment_style             ->  options.styles.comments
+  • function_style            ->  options.styles.functions
+  • keyword_style             ->  options.styles.keywords
+  • variable_style            ->  options.styles.variables
+  • msg_area_style            ->  Removed.
 
 
-
-                                                *github-theme.changelog-11042023*
-
-Date: April 11, 2023
+                                               *github-theme.changelog-11042023*
+--------------------------------------------------------------------------------
+April 11, 2023
 
 In the |setup| function, the |theme_style| option has been removed, and the
 process of setting the colorscheme has been changed, It is important to note
@@ -164,10 +291,9 @@ New approach for setting the theme:
 <
 
 
-
-                                                *github-theme.changelog-06042023*
-
-Date: April 06, 2023
+                                               *github-theme.changelog-06042023*
+--------------------------------------------------------------------------------
+April 06, 2023
 
 The secondary method of assigning configuration variables using
 `'vim.g.github_*'` is now considered deprecated. Instead, it is recommended to
@@ -178,14 +304,13 @@ Any references to the deprecated modules and options can be found in the
 documentation located at `:h github-theme.deprecated`.
 
 
-
-                                                *github-theme.changelog-03012023*
-
-Date: January 03, 2023
+                                               *github-theme.changelog-03012023*
+--------------------------------------------------------------------------------
+January 03, 2023
 
 PR: https://github.com/projekt0n/github-nvim-theme/pull/222
 
-I (ful1e5) wanted to let you know that we now have support for new treesitter
+I (@ful1e5) wanted to let you know that we now have support for new treesitter
 highlighting groups, thanks to a contribution from `@luisiacc`. If you are
 using an older version of treesitter, please switch to the `v0.7` release tag,
 which is the last version for you to take advantage of the old treesitter
@@ -193,16 +318,15 @@ highlights. We will continue to develop and support these new highlighting
 groups going forward.
 
 In addition, I am planning a major refactor of the codebase to make it
-compatible with `Neovim-0.9` and will be starting a discussion on GitHub soon.
+compatible with `neovim-0.9` and will be starting a discussion on GitHub soon.
 To ensure that the community is aware of any major changes before they are
 implemented, I will provide advance warning before any potentially breaking
 changes are pushed to upstream.
 
 
-
-                                                *github-theme.changelog-03082022*
-
-Date: August 03, 2022
+                                               *github-theme.changelog-03082022*
+--------------------------------------------------------------------------------
+August 03, 2022
 
 Terminal themes moved to projekt0n/github-theme-contrib repo and all related
 code have been removed from this repository.
@@ -210,10 +334,9 @@ code have been removed from this repository.
 URL: https://github.com/projekt0n/github-theme-contrib
 
 
-
-                                                *github-theme.changelog-13122021*
-
-Date: December 13, 2021
+                                               *github-theme.changelog-13122021*
+--------------------------------------------------------------------------------
+December 13, 2021
 
 PR: https://github.com/projekt0n/github-nvim-theme/pull/148
 
@@ -222,12 +345,11 @@ tabline from the background.
 
 A list of changes that have been made:
 
-- Minimal look deprecated for `lualine` plugin. This deprecation is related to
-  `hide_inactive_statusline` option. This means the theme will not force the
-  `underline` style to inactive lualine.
-- Native lualine theme support terminal highlights `terminal-config`
-- Inactive tabline highlights got enhanced.
+  • Minimal look deprecated for `lualine` plugin. This deprecation is related to
+    `hide_inactive_statusline` option. This means the theme will not force the
+    `underline` style to inactive lualine.
+  • Native lualine theme support terminal highlights `terminal-config`
+  • Inactive tabline highlights got enhanced.
 
 
-
- vim:tw=78:ts=8:ft=help:norl:
+ vim:tw=80:ts=8:sw=2:et:ft=help:norl:

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -2,53 +2,31 @@ local collect = require('github-theme.lib.collect')
 local util = require('github-theme.util')
 local M = { theme = 'github_dark', has_options = false }
 
+---@alias GhTheme.Config.Options.Filetype string A neovim `filetype`.
+
 -- TODO: improve type of `specs` and `palettes`
 ---@class (exact) GhTheme.Config
 ---@field options? GhTheme.Config.Options
----@field palettes? table
----@field specs? table
+---@field palettes? table<GhTheme.Theme|"all", table>
+---@field specs? table<GhTheme.Theme|"all", table>
 ---@field groups? table<GhTheme.Theme|"all", table<string, GhTheme.HighlightGroup>>
 
 ---@class (exact) GhTheme.Config.Module
 ---@field enable? boolean whether to set plugin-specific highlights for this module/plugin
 
----@class (exact) GhTheme.Config.Module.Coc: GhTheme.Config.Module
----@field background? boolean whether to set background color of virtual text
-
----@class (exact) GhTheme.Config.Module.Diagnostic: GhTheme.Config.Module
----@field background? boolean whether to set background color of virtual text
-
----@class (exact) GhTheme.Config.Module.NativeLSP: GhTheme.Config.Module
----@field background? boolean whether to set background color of virtual text
-
----Config for external modules/plugins.
----@class (exact) GhTheme.Config.Options.Modules
----@field cmp? boolean|GhTheme.Config.Module
----@field coc? boolean|GhTheme.Config.Module.Coc
----@field coc_explorer? boolean|GhTheme.Config.Module
----@field dapui? boolean|GhTheme.Config.Module
----@field diffchar? boolean|GhTheme.Config.Module
----@field dashboard? boolean|GhTheme.Config.Module
----@field diagnostic? boolean|GhTheme.Config.Module.Diagnostic
----@field fidget? boolean|GhTheme.Config.Module
----@field fzf? boolean|GhTheme.Config.Module
----@field gitgutter? boolean|GhTheme.Config.Module
----@field gitsigns? boolean|GhTheme.Config.Module
----@field indent_blankline? boolean|GhTheme.Config.Module
----@field lsp_semantic_tokens? boolean|GhTheme.Config.Module
----@field lsp_trouble? boolean|GhTheme.Config.Module
----@field mini? boolean|GhTheme.Config.Module
----@field native_lsp? boolean|GhTheme.Config.Module.NativeLSP
----@field neogit? boolean|GhTheme.Config.Module
----@field neotree? boolean|GhTheme.Config.Module
----@field notify? boolean|GhTheme.Config.Module
----@field nvimtree? boolean|GhTheme.Config.Module
----@field telescope? boolean|GhTheme.Config.Module
----@field treesitter? boolean|GhTheme.Config.Module
----@field treesitter_context? boolean|GhTheme.Config.Module
----@field whichkey? boolean|GhTheme.Config.Module
-
----@class GhTheme.Config.Options
+---@class (exact) GhTheme.Config.Options
+---@field compile_file_suffix? string
+---@field compile_path? string
+---@field hide_end_of_buffer? boolean
+---@field hide_nc_statusline? boolean
+---@field transparent? boolean
+---@field terminal_colors? boolean
+---@field dim_inactive? boolean
+---@field module_default? boolean
+---@field styles? GhTheme.Config.Options.Styles
+---@field inverse? GhTheme.Config.Options.Inverse
+---@field darken? GhTheme.Config.Options.Darken
+---@field modules? GhTheme.Config.Options.Modules
 local defaults = {
   compile_file_suffix = '_compiled',
   compile_path = util.join_paths(util.cache_home, 'github-theme'),
@@ -58,76 +36,119 @@ local defaults = {
   terminal_colors = true,
   dim_inactive = false,
   module_default = true,
+
+  ---A table of syntax items/groups and their corresponding styles.
+  ---@class (exact) GhTheme.Config.Options.Styles
+  ---@field comments? GhTheme.HighlightGroup.Style
+  ---@field functions? GhTheme.HighlightGroup.Style
+  ---@field keywords? GhTheme.HighlightGroup.Style
+  ---@field variables? GhTheme.HighlightGroup.Style
+  ---@field conditionals? GhTheme.HighlightGroup.Style
+  ---@field constants? GhTheme.HighlightGroup.Style
+  ---@field numbers? GhTheme.HighlightGroup.Style
+  ---@field operators? GhTheme.HighlightGroup.Style
+  ---@field strings? GhTheme.HighlightGroup.Style
+  ---@field types? GhTheme.HighlightGroup.Style
   styles = {
-    ---@type GhTheme.HighlightGroup.Style
     comments = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     functions = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     keywords = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     variables = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     conditionals = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     constants = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     numbers = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     operators = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     strings = 'NONE',
-
-    ---@type GhTheme.HighlightGroup.Style
     types = 'NONE',
   },
+
+  ---The `inverse` table contains a list of highlight types. If a highlight type is
+  ---enabled, the `fg` and `bg` colors will be inversed/reversed (swapped).
+  ---
+  ---For example, if `search` is enabled, then the foreground and background colors of
+  ---highlighted search terms will be swapped.
+  ---@class (exact) GhTheme.Config.Options.Inverse
+  ---@field match_paren? boolean invert highlight of matching parenthesis (`:help matchparen`)
+  ---@field visual? boolean invert highlight of visual mode selection
+  ---@field search? boolean invert highlight of current search term
   inverse = {
     match_paren = false,
     visual = false,
     search = false,
   },
+
+  ---@class (exact) GhTheme.Config.Options.Darken
+  ---@field floats? boolean whether to darken the `bg` of floating windows (default `true`)
+  ---@field sidebars? GhTheme.Config.Options.Darken.Sidebars
   darken = {
     floats = true,
+
+    ---@class (exact) GhTheme.Config.Options.Darken.Sidebars
+    ---@field enable? boolean whether to darken the `bg` of sidebars (i.e. sidebar windows) (default `true`)
+    ---@field list? (GhTheme.Config.Options.Filetype|"terminal")[] list of sidebars whose `bg` will be darkened
     sidebars = {
       enable = true,
-      ---List of (filetype or `'terminal'`) whose bg will be darkened.
       list = {},
     },
   },
 
-  ---@type GhTheme.Config.Options.Modules
+  ---Config for external modules/plugins.
+  ---@class (exact) GhTheme.Config.Options.Modules
+  ---@field cmp? boolean|GhTheme.Config.Module
+  ---@field coc? boolean|GhTheme.Config.Module.Coc
+  ---@field coc_explorer? boolean|GhTheme.Config.Module
+  ---@field dapui? boolean|GhTheme.Config.Module
+  ---@field diffchar? boolean|GhTheme.Config.Module
+  ---@field dashboard? boolean|GhTheme.Config.Module
+  ---@field diagnostic? boolean|GhTheme.Config.Module.Diagnostic
+  ---@field fidget? boolean|GhTheme.Config.Module
+  ---@field fzf? boolean|GhTheme.Config.Module
+  ---@field gitgutter? boolean|GhTheme.Config.Module
+  ---@field gitsigns? boolean|GhTheme.Config.Module
+  ---@field indent_blankline? boolean|GhTheme.Config.Module
+  ---@field lsp_semantic_tokens? boolean|GhTheme.Config.Module
+  ---@field lsp_trouble? boolean|GhTheme.Config.Module
+  ---@field mini? boolean|GhTheme.Config.Module
+  ---@field native_lsp? boolean|GhTheme.Config.Module.NativeLSP
+  ---@field neogit? boolean|GhTheme.Config.Module
+  ---@field neotree? boolean|GhTheme.Config.Module
+  ---@field notify? boolean|GhTheme.Config.Module
+  ---@field nvimtree? boolean|GhTheme.Config.Module
+  ---@field telescope? boolean|GhTheme.Config.Module
+  ---@field treesitter? boolean|GhTheme.Config.Module
+  ---@field treesitter_context? boolean|GhTheme.Config.Module
+  ---@field whichkey? boolean|GhTheme.Config.Module
   modules = {
+
+    ---@class (exact) GhTheme.Config.Module.Coc: GhTheme.Config.Module
+    ---@field enable? boolean
+    ---@field background? boolean whether to set background color of virtual text
     coc = {
       background = true,
     },
+
+    ---@class (exact) GhTheme.Config.Module.Diagnostic: GhTheme.Config.Module
+    ---@field enable? boolean
+    ---@field background? boolean whether to set background color of virtual text
     diagnostic = {
-      -- This is linked to so much that is needs to be enabled. This is here primarily
-      -- for the extra options that can be added with modules
+      -- This is linked to so much that is needs to be enabled. This is here primarily for
+      -- the extra options that can be added with modules.
       enable = true,
       background = false,
     },
+
+    ---@class (exact) GhTheme.Config.Module.NativeLSP: GhTheme.Config.Module
+    ---@field enable? boolean
+    ---@field background? boolean whether to set background color of virtual text
     native_lsp = {
       enable = util.is_nvim,
       background = true,
     },
+
     treesitter = util.is_nvim,
     lsp_semantic_tokens = util.is_nvim,
   },
 }
-
--- The following is done to disallow the addition of any more fields.
-
----@type GhTheme.Config.Options
----@diagnostic disable-next-line: redefined-local
-local defaults = defaults
 
 M.options = collect.deep_copy(defaults)
 

--- a/lua/github-theme/group/modules/treesitter.lua
+++ b/lua/github-theme/group/modules/treesitter.lua
@@ -17,6 +17,7 @@ function M.get(spec, config, _opts)
   local syn = spec.syntax
   local stl = config.styles
   local P = spec.palette
+  ---@cast stl -?
 
   ---Clears nvim's default highlighting for a highlight-group and allows
   ---falling-back to another hl-group when multiple highlights/groups are
@@ -263,7 +264,7 @@ If you want to stay on nvim 0.7, disable the module, or track on 'v0.0.x' branch
     ['@lsp.type.variable.lua']                  = { fg = spec.variable },
     ['@constructor.lua']                        = { fg = syn.bracket },                         -- {}
     ['@operator.lua']                           = { fg = syn.keyword, style = stl.operators },
- -- ['@variable.member.lua']                    = { fg = syn.variable },
+ -- ['@property']                               = { fg = syn.variable },
  -- ['@function.call.lua']                      = { fg = syn.const },
  -- ['@function.method.call.lua']               = { link = '@function.call.lua' },
     ['@function.builtin.lua']                   = { fg = syn.builtin0, style = stl.functions },


### PR DESCRIPTION
The diff appears to be large, but the changes are fairly trivial. For reference, here's a quick summary of the changes:

- Tweaked `CHANGELOG.md` (reduced indent from 3 to 2 spaces, reworded a couple things, fixed the URLs at the end of the file which were invalid comparisons/revision ranges)
- Finalized the `CHANGELOG` entry for this release. I decided on a minor release instead of patch release as there are several bug fixes and changes since `v1.0.2`, and also because of all of the highlight group changes made upstream.
- Tweaked the vimdoc changelog (improved imo). I replaced `-` with real unicode bullet points, fixed-up indenting and alignment (aligned elements to 80 chars according to the current modeline, tags should be right-aligned and either on the same line as the title/heading or the very next one up), improved the sections (e.g. added `--------` section delimiters). I also added an entry to this changelog as well which covers all of the new and renamed hl groups as of nvim `v0.10` (since the beginning of this year, 2024).
- Lastly I improved and strengthened the config types  in `config.lua` (which are also/mainly used for the argument to `setup()` in order to provide LSP completion for users as well as help catch invalid keys/assignments/values in user config).

> [!NOTE]
> I applied the class definitions in `config.lua` directly to the `defaults` table literal for a few reasons. One, it seems to improve the type-checking of `defaults` (because lua-ls is weird), particularly when it comes to the table literals nested within `defaults` (in comparison to just using `---@type SomeClassName` on the `defaults` table). Two, it keeps the types/classes close-by when modifying the defaults themselves (i.e. the values) (e.g. you'll usually want to update both at the same time and keep them in-sync). On the other hand, doing it this way does make the file somewhat uglier and harder to read, but it's manageable.