### PR TITLE
ci(primitives): run less often, run on pull requests

### DIFF
--- a/.github/workflows/update-color-primitives.yml
+++ b/.github/workflows/update-color-primitives.yml
@@ -1,21 +1,30 @@
 name: Get/Update Primer Color Primitives
 
 env:
-  _DEST_DIR: "${{ github.workspace }}/lua/github-theme/palette/primitives"
-  _JSON_DIR: "${{ github.workspace }}/node_modules/@primer/primitives/dist/json/colors"
-  _LICENSE_GLOB: "${{ github.workspace }}/node_modules/@primer/primitives/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]*"
-  _PRIMITIVES_PKGJSON: "${{ github.workspace }}/node_modules/@primer/primitives/package.json"
+  _DEST_DIR: '${{ github.workspace }}/lua/github-theme/palette/primitives'
+  _JSON_DIR: '${{ github.workspace }}/node_modules/@primer/primitives/dist/json/colors'
+  _LICENSE_GLOB: '${{ github.workspace }}/node_modules/@primer/primitives/[Ll][Ii][Cc][Ee][Nn][Ss][Ee]*'
+  _PRIMITIVES_PKGJSON: '${{ github.workspace }}/node_modules/@primer/primitives/package.json'
 
 on:
   workflow_dispatch:
   schedule:
-    # 3x per week (every other day) at 12:40pm Pacific Time
-    - cron: "40 19 * * 1,3,5"
+    - cron: '40 19 */14 * *' # Roughly every 14 days (at 12:40pm Pacific Time)
+  push:
+    branches:
+      - '**' # Any branch, but ignore tag pushes
+    paths:
+      - .github/workflows/**/*
+      - scripts/**/*
+  pull_request:
+    paths:
+      - .github/workflows/**/*
+      - scripts/**/*
 
 jobs:
   get-colors:
     runs-on: ubuntu-latest
-    permissions:
+    permissions: # NOTE: `write` is not applied for PR's from forks
       checks: write
       contents: write
       issues: write
@@ -28,12 +37,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: lts/*
           check-latest: true
 
       - run: npm i @primer/primitives@latest
 
-      - run: |
+      - name: Generate Lua files
+        run: |
           set -u +f
           shopt -s nocaseglob failglob
           license="$(<$_LICENSE_GLOB)"
@@ -56,15 +66,38 @@ jobs:
           EOF
           done
 
-      - uses: JohnnyMorganz/stylua-action@v4
+      - name: Check formatting (stylua)
+        uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: -f stylua.toml --verify -- ${{ env._DEST_DIR }}
 
-      - uses: peter-evans/create-pull-request@v6
+      - id: diff
+        run: git diff --quiet -- "$_DEST_DIR" || echo has_diff=true >> "$GITHUB_OUTPUT"
+
+      - if: ${{ steps.diff.outputs.has_diff }}
+        uses: actions/upload-artifact@v4
         with:
-          commit-message: Update color primitives
-          branch: update-color-primitives
+          name: primitives
+          path: ${{ env._DEST_DIR }}
+          retention-days: ${{ (github.event_name != 'push' || github.ref_name != 'main') && 14 || null }}
+          if-no-files-found: error
+          overwrite: true
+
+      - if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
           delete-branch: true
-          title: Update color primitives
+          branch: generated/primitives/${{ github.ref_name }}
+          commit-message: 'deps: update color primitives'
+          title: 'deps: update color primitives'
+          body: |
+            |                   |                          |
+            | ----------------- | ------------------------ |
+            | **Trigger**       | ${{ github.event_name }} |
+            | **Target Branch** | ${{ github.ref_name }}   |
+
+            > [!NOTE]
+            > Checks are not automatically run for this PR.
+            > Close and reopen this PR to run tests and checks (against the newly generated primitives).


### PR DESCRIPTION
- Run every 2 weeks (roughly) instead of 3x/week.

- Run on pull requests also, so that changes to the workflow file and its dependencies can be "tested" prior to merging. This does not run tests against the generated primitives however.