### PR TITLE
fix(Color): don't use shared global state (`Color.BG` etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 ### Issues Fix
 
 -  Fixed JSX/TSX tags are missing highlights with nvim 0.10 (#360)
+-  Fixed loading palette or spec before colorscheme disrupts colors (#362 fixed-by #363)
 
 ## [v1.1.2] - 05 August 2024
 

--- a/lua/github-theme/group/modules/treesitter.lua
+++ b/lua/github-theme/group/modules/treesitter.lua
@@ -8,7 +8,7 @@ function M.get(spec, config, _opts)
   --       being integrated.
   local primitives = require(
     'github-theme.palette.primitives.'
-      .. require('github-theme.config').theme
+      .. spec.palette.meta.name
         :gsub('^github_(.-)_default$', '%1')
         :gsub('^github_(.-)$', '%1')
   )

--- a/lua/github-theme/lib/color.lua
+++ b/lua/github-theme/lib/color.lua
@@ -336,7 +336,7 @@ end
 
 ---Returns a new Color that is a linear blend between `self` and `other`.
 ---@param other GhTheme.Color
----@param f number Float [0,1] where 0 is `self` and 1 is `other`
+---@param f number float `[0,1]` where `0` is `self` and `1` is `other`
 ---@return GhTheme.Color
 ---@nodiscard
 function Color:blend(other, f)
@@ -349,20 +349,18 @@ function Color:blend(other, f)
 end
 
 ---Returns a new Color that is a linear blend between `Color.BG` and `self`.
----@param f number Float [0,1] where 0 is `Color.BG` and 1 is `self`
+---
+---> WARNING: This method might not work correctly until ***after*** the colorscheme has
+---> loaded, or `Color.BG` has been set! DO NOT USE INTERNALLY!
+---@param alpha number float (`[0,1]`) where `0` is `Color.BG` and `1` is `self`
 ---@return GhTheme.Color
 ---@nodiscard
-function Color:alpha_blend(f)
-  return M.init(
-    (self.red - self.BG.red) * f + self.BG.red,
-    (self.green - self.BG.green) * f + self.BG.green,
-    (self.blue - self.BG.blue) * f + self.BG.blue,
-    self.alpha
-  )
+function Color:alpha_blend(alpha)
+  return self.BG:blend(self, alpha)
 end
 
 ---Returns a new Color which is `self` shaded according to `f`.
----@param f number Amount. Float [-1,1]. -1 is black and 1 is white
+---@param f number float (`[-1,1]`) where `-1` is black and `1` is white
 ---@return GhTheme.Color
 ---@nodiscard
 function Color:shade(f)
@@ -377,9 +375,9 @@ function Color:shade(f)
   )
 end
 
----Adds value of `v` to the `value` of the current color. Returns a new Color
----that is either a brighter version (v >= 0), or darker (v < 0).
----@param v number Value. Float [-100,100].
+---Adds value of `v` to the `value` of the current color. Returns a new Color that is
+---either a brighter version (`v >= 0`), or darker (`v < 0`).
+---@param v number Value. Float `[-100,100]`.
 ---@return GhTheme.Color
 ---@nodiscard
 function Color:brighten(v)
@@ -390,7 +388,7 @@ end
 
 ---Adds value of `v` to the `lightness` of the current color. Returns a new Color
 ---that is either a lighter version if +v and darker if -v.
----@param v number Lightness. Float [-100,100].
+---@param v number Lightness. Float `[-100,100]`.
 ---@return GhTheme.Color
 ---@nodiscard
 function Color:lighten(v)
@@ -411,7 +409,7 @@ function Color:saturate(v)
 end
 
 ---Adds value of `v` to the `hue` of the current color. Returns a new Color where
----the hue is rotated based on +/- of `v`. Resulting `hue` is wrapped [0,360].
+---the hue is rotated based on +/- of `v`. Resulting `hue` is wrapped `[0,360]`.
 ---@param v number amount
 ---@return GhTheme.Color
 ---@nodiscard

--- a/lua/github-theme/lib/compiler.lua
+++ b/lua/github-theme/lib/compiler.lua
@@ -87,8 +87,8 @@ vim.g.colors_name = "%s"
 
   file = io.open(output_file, 'wb')
 
-  local f = loadstring(table.concat(lines, '\n'), '=')
-  if not f then
+  local dump_theme = loadstring(table.concat(lines, '\n'), 'dump_theme')
+  if not dump_theme then
     local tmpfile = util.join_paths(util.get_tmp_dir(), 'github_theme_error.lua')
     require('github-theme.lib.log').error(
       fmt(
@@ -109,7 +109,7 @@ Bellow is the error message:
     dofile(tmpfile)
   end
 
-  file:write(f())
+  file:write(dump_theme())
   file:close()
 end
 

--- a/lua/github-theme/palette/github_dark.lua
+++ b/lua/github-theme/palette/github_dark.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(scale.gray[7])
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(scale.gray[7])
 
 local palette = {
   scale = scale,
@@ -52,86 +49,86 @@ local palette = {
   border = {
     default = scale.gray[9],
     muted = scale.gray[8],
-    subtle = alpha(C.from_rgba(240, 246, 252, 1), 0.1),
+    subtle = BG:blend(C.from_rgba(240, 246, 252, 1), 0.1):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[5],
     emphasis = scale.gray[5],
-    muted = alpha(C.from_rgba(110, 118, 129, 1), 0.4),
-    subtle = alpha(C.from_rgba(110, 118, 129, 1), 0.1),
+    muted = BG:blend(C.from_rgba(110, 118, 129, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(110, 118, 129, 1), 0.1):to_css(),
   },
 
   accent = {
     fg = '#2f81f7',
     emphasis = scale.blue[6],
-    muted = alpha(C.from_rgba(56, 139, 253, 1), 0.4),
-    subtle = alpha(C.from_rgba(56, 139, 253, 1), 0.15),
+    muted = BG:blend(C.from_rgba(56, 139, 253, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(56, 139, 253, 1), 0.15):to_css(),
   },
 
   success = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   attention = {
     fg = scale.yellow[4],
     emphasis = scale.yellow[6],
-    muted = alpha(C.from_rgba(187, 128, 9, 1), 0.4),
-    subtle = alpha(C.from_rgba(187, 128, 9, 1), 0.15),
+    muted = BG:blend(C.from_rgba(187, 128, 9, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(187, 128, 9, 1), 0.15):to_css(),
   },
 
   severe = {
     fg = scale.orange[5],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_rgba(219, 109, 40, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 109, 40, 1), 0.1),
+    muted = BG:blend(C.from_rgba(219, 109, 40, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 109, 40, 1), 0.1):to_css(),
   },
 
   danger = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.1),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.1):to_css(),
   },
 
   open = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   done = {
     fg = scale.purple[5],
     emphasis = scale.purple[6],
-    muted = alpha(C.from_rgba(163, 113, 247, 1), 0.4),
-    subtle = alpha(C.from_rgba(163, 113, 247, 1), 0.1),
+    muted = BG:blend(C.from_rgba(163, 113, 247, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(163, 113, 247, 1), 0.1):to_css(),
   },
 
   closed = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   sponsors = {
     fg = scale.pink[5],
     emphasis = scale.pink[6],
-    muted = alpha(C.from_rgba(219, 97, 162, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 97, 162, 1), 0.1),
+    muted = BG:blend(C.from_rgba(219, 97, 162, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 97, 162, 1), 0.1):to_css(),
   },
 }
 
 local function generate_spec(pal)
   -- stylua: ignore start
   local spec = {
-    bg0  = alpha(C(pal.canvas.inset), 0.75),            -- Dark bg (popup and float)
+    bg0  = BG:blend(C(pal.canvas.inset), 0.75):to_css(),         -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
     bg3  = pal.scale.gray[6],                           -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[4],                           -- Conceal
 
@@ -140,9 +137,9 @@ local function generate_spec(pal)
     fg2  = pal.fg.muted,                                -- Darker fg (status line)
     fg3  = pal.scale.gray[5],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.30),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.scale.yellow[1]), 0.20),         -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.30):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.scale.yellow[1]), 0.20):to_css(),      -- Search bg
   }
 
   spec.syntax = {
@@ -178,16 +175,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[6]), 0.15),
-    delete = alpha(C(pal.scale.red[6]), 0.15),
-    change = alpha(C(pal.scale.yellow[6]), 0.15),
+    add    = BG:blend(C(pal.scale.green[6]), 0.15):to_css(),
+    delete = BG:blend(C(pal.scale.red[6]), 0.15):to_css(),
+    change = BG:blend(C(pal.scale.yellow[6]), 0.15):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_dark_colorblind.lua
+++ b/lua/github-theme/palette/github_dark_colorblind.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 local palette = {
   scale = scale,
@@ -47,86 +44,86 @@ local palette = {
   border = {
     default = scale.gray[7],
     muted = scale.gray[8],
-    subtle = alpha(C.from_rgba(240, 246, 252, 1), 0.1),
+    subtle = BG:blend(C.from_rgba(240, 246, 252, 1), 0.1):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[5],
     emphasis = scale.gray[5],
-    muted = alpha(C.from_rgba(110, 118, 129, 1), 0.4),
-    subtle = alpha(C.from_rgba(110, 118, 129, 1), 0.1),
+    muted = BG:blend(C.from_rgba(110, 118, 129, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(110, 118, 129, 1), 0.1):to_css(),
   },
 
   accent = {
     fg = scale.blue[4],
     emphasis = scale.blue[6],
-    muted = alpha(C.from_rgba(56, 139, 253, 1), 0.4),
-    subtle = alpha(C.from_rgba(56, 139, 253, 1), 0.15),
+    muted = BG:blend(C.from_rgba(56, 139, 253, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(56, 139, 253, 1), 0.15):to_css(),
   },
 
   success = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   attention = {
     fg = scale.yellow[4],
     emphasis = scale.yellow[6],
-    muted = alpha(C.from_rgba(187, 128, 9, 1), 0.4),
-    subtle = alpha(C.from_rgba(187, 128, 9, 1), 0.15),
+    muted = BG:blend(C.from_rgba(187, 128, 9, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(187, 128, 9, 1), 0.15):to_css(),
   },
 
   severe = {
     fg = scale.orange[5],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_rgba(219, 109, 40, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 109, 40, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 109, 40, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 109, 40, 1), 0.15):to_css(),
   },
 
   danger = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   open = {
     fg = scale.orange[4],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_hex(scale.orange[5]), 0.4),
-    subtle = alpha(C.from_hex(scale.orange[5]), 0.15),
+    muted = BG:blend(C.from_hex(scale.orange[5]), 0.4):to_css(),
+    subtle = BG:blend(C.from_hex(scale.orange[5]), 0.15):to_css(),
   },
 
   done = {
     fg = scale.purple[5],
     emphasis = scale.purple[6],
-    muted = alpha(C.from_rgba(163, 113, 247, 1), 0.4),
-    subtle = alpha(C.from_rgba(163, 113, 247, 1), 0.15),
+    muted = BG:blend(C.from_rgba(163, 113, 247, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(163, 113, 247, 1), 0.15):to_css(),
   },
 
   closed = {
     fg = scale.gray[4],
     emphasis = scale.gray[5],
-    muted = alpha(C.from_hex(scale.gray[5]), 0.4),
-    subtle = alpha(C.from_hex(scale.gray[5]), 0.10),
+    muted = BG:blend(C.from_hex(scale.gray[5]), 0.4):to_css(),
+    subtle = BG:blend(C.from_hex(scale.gray[5]), 0.10):to_css(),
   },
 
   sponsors = {
     fg = scale.pink[5],
     emphasis = scale.pink[6],
-    muted = alpha(C.from_rgba(219, 97, 162, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 97, 162, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 97, 162, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 97, 162, 1), 0.15):to_css(),
   },
 }
 
 local function generate_spec(pal)
   -- stylua: ignore start
   local spec = {
-    bg0  = alpha(C(pal.canvas.inset), 0.75),            -- Dark bg (status line, popup and float)
+    bg0  = BG:blend(C(pal.canvas.inset), 0.75):to_css(),         -- Dark bg (status line, popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
     bg3  = pal.scale.gray[9],                           -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[4],                           -- Conceal
 
@@ -135,9 +132,9 @@ local function generate_spec(pal)
     fg2  = pal.fg.muted,                                -- Darker fg (status line)
     fg3  = pal.scale.gray[5],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.45),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.scale.yellow[3]), 0.60),         -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.45):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.scale.yellow[3]), 0.60):to_css(),      -- Search bg
   }
 
   spec.syntax = {
@@ -173,16 +170,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[6]), 0.15),
-    delete = alpha(C(pal.scale.red[6]), 0.15),
-    change = alpha(C(pal.scale.yellow[6]), 0.15),
+    add    = BG:blend(C(pal.scale.green[6]), 0.15):to_css(),
+    delete = BG:blend(C(pal.scale.red[6]), 0.15):to_css(),
+    change = BG:blend(C(pal.scale.yellow[6]), 0.15):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_dark_default.lua
+++ b/lua/github-theme/palette/github_dark_default.lua
@@ -13,10 +13,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 local palette = {
   scale = scale,
@@ -46,86 +43,86 @@ local palette = {
   border = {
     default = scale.gray[9],
     muted = scale.gray[8],
-    subtle = alpha(C.from_rgba(240, 246, 252, 1), 0.1),
+    subtle = BG:blend(C.from_rgba(240, 246, 252, 1), 0.1):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[5],
     emphasis = scale.gray[5],
-    muted = alpha(C.from_rgba(110, 118, 129, 1), 0.4),
-    subtle = alpha(C.from_rgba(110, 118, 129, 1), 0.1),
+    muted = BG:blend(C.from_rgba(110, 118, 129, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(110, 118, 129, 1), 0.1):to_css(),
   },
 
   accent = {
     fg = '#2f81f7',
     emphasis = scale.blue[6],
-    muted = alpha(C.from_rgba(56, 139, 253, 1), 0.4),
-    subtle = alpha(C.from_rgba(56, 139, 253, 1), 0.15),
+    muted = BG:blend(C.from_rgba(56, 139, 253, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(56, 139, 253, 1), 0.15):to_css(),
   },
 
   success = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   attention = {
     fg = scale.yellow[4],
     emphasis = scale.yellow[6],
-    muted = alpha(C.from_rgba(187, 128, 9, 1), 0.4),
-    subtle = alpha(C.from_rgba(187, 128, 9, 1), 0.15),
+    muted = BG:blend(C.from_rgba(187, 128, 9, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(187, 128, 9, 1), 0.15):to_css(),
   },
 
   severe = {
     fg = scale.orange[5],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_rgba(219, 109, 40, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 109, 40, 1), 0.1),
+    muted = BG:blend(C.from_rgba(219, 109, 40, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 109, 40, 1), 0.1):to_css(),
   },
 
   danger = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.1),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.1):to_css(),
   },
 
   open = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   done = {
     fg = scale.purple[5],
     emphasis = scale.purple[6],
-    muted = alpha(C.from_rgba(163, 113, 247, 1), 0.4),
-    subtle = alpha(C.from_rgba(163, 113, 247, 1), 0.1),
+    muted = BG:blend(C.from_rgba(163, 113, 247, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(163, 113, 247, 1), 0.1):to_css(),
   },
 
   closed = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   sponsors = {
     fg = scale.pink[5],
     emphasis = scale.pink[6],
-    muted = alpha(C.from_rgba(219, 97, 162, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 97, 162, 1), 0.1),
+    muted = BG:blend(C.from_rgba(219, 97, 162, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 97, 162, 1), 0.1):to_css(),
   },
 }
 
 local function generate_spec(pal)
   -- stylua: ignore start
   local spec = {
-    bg0  = alpha(C(pal.canvas.inset), 0.75),            -- Dark bg (popup and float)
+    bg0  = BG:blend(C(pal.canvas.inset), 0.75):to_css(),         -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
     bg3  = pal.scale.gray[6],                           -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[4],                           -- Conceal
 
@@ -134,9 +131,9 @@ local function generate_spec(pal)
     fg2  = pal.fg.muted,                                -- Darker fg (status line)
     fg3  = pal.scale.gray[5],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.30),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.scale.yellow[1]), 0.20),         -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.30):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.scale.yellow[1]), 0.20):to_css(),      -- Search bg
   }
 
   spec.syntax = {
@@ -172,16 +169,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[6]), 0.15),
-    delete = alpha(C(pal.scale.red[6]), 0.15),
-    change = alpha(C(pal.scale.yellow[6]), 0.15),
+    add    = BG:blend(C(pal.scale.green[6]), 0.15):to_css(),
+    delete = BG:blend(C(pal.scale.red[6]), 0.15):to_css(),
+    change = BG:blend(C(pal.scale.yellow[6]), 0.15):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_dark_dimmed.lua
+++ b/lua/github-theme/palette/github_dark_dimmed.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 local palette = {
   scale = scale,
@@ -47,87 +44,87 @@ local palette = {
   border = {
     default = scale.gray[7],
     muted = scale.gray[8],
-    subtle = alpha(C.from_rgba(240, 246, 252, 1), 0.1),
+    subtle = BG:blend(C.from_rgba(240, 246, 252, 1), 0.1):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[5],
     emphasis = scale.gray[5],
-    muted = alpha(C.from_rgba(110, 118, 129, 1), 0.4),
-    subtle = alpha(C.from_rgba(110, 118, 129, 1), 0.1),
+    muted = BG:blend(C.from_rgba(110, 118, 129, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(110, 118, 129, 1), 0.1):to_css(),
   },
 
   accent = {
     fg = scale.blue[4],
     emphasis = scale.blue[6],
-    muted = alpha(C.from_rgba(56, 139, 253, 1), 0.4),
-    subtle = alpha(C.from_rgba(56, 139, 253, 1), 0.15),
+    muted = BG:blend(C.from_rgba(56, 139, 253, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(56, 139, 253, 1), 0.15):to_css(),
   },
 
   success = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   attention = {
     fg = scale.yellow[4],
     emphasis = scale.yellow[6],
-    muted = alpha(C.from_rgba(187, 128, 9, 1), 0.4),
-    subtle = alpha(C.from_rgba(187, 128, 9, 1), 0.15),
+    muted = BG:blend(C.from_rgba(187, 128, 9, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(187, 128, 9, 1), 0.15):to_css(),
   },
 
   severe = {
     fg = scale.orange[5],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_rgba(219, 109, 40, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 109, 40, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 109, 40, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 109, 40, 1), 0.15):to_css(),
   },
 
   danger = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   open = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   done = {
     fg = scale.purple[5],
     emphasis = scale.purple[6],
-    muted = alpha(C.from_rgba(163, 113, 247, 1), 0.4),
-    subtle = alpha(C.from_rgba(163, 113, 247, 1), 0.15),
+    muted = BG:blend(C.from_rgba(163, 113, 247, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(163, 113, 247, 1), 0.15):to_css(),
   },
 
   closed = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   sponsors = {
     fg = scale.pink[5],
     emphasis = scale.pink[6],
-    muted = alpha(C.from_rgba(219, 97, 162, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 97, 162, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 97, 162, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 97, 162, 1), 0.15):to_css(),
   },
 }
 
 local function generate_spec(pal)
   -- stylua: ignore start
   local spec = {
-    bg0  = alpha(C(pal.canvas.inset), 0.75),            -- Dark bg (popup and float)
+    bg0  = BG:blend(C(pal.canvas.inset), 0.75):to_css(),         -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
-    bg3  = alpha(C(pal.fg.default), 0.1),               -- Lighter bg (cursor line)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
+    bg3  = BG:blend(C(pal.fg.default), 0.1):to_css(),            -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[4],                           -- Conceal
 
     fg0  = pal.fg.subtle,                               -- Lighter fg
@@ -135,9 +132,9 @@ local function generate_spec(pal)
     fg2  = pal.fg.muted,                                -- Darker fg (status line)
     fg3  = pal.scale.gray[5],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.40),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.scale.yellow[1]), 0.20),         -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.40):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.scale.yellow[1]), 0.20):to_css(),      -- Search bg
   }
 
   spec.syntax = {
@@ -173,16 +170,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[6]), 0.15),
-    delete = alpha(C(pal.scale.red[6]), 0.15),
-    change = alpha(C(pal.scale.yellow[6]), 0.15),
+    add    = BG:blend(C(pal.scale.green[6]), 0.15):to_css(),
+    delete = BG:blend(C(pal.scale.red[6]), 0.15):to_css(),
+    change = BG:blend(C(pal.scale.yellow[6]), 0.15):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_dark_high_contrast.lua
+++ b/lua/github-theme/palette/github_dark_high_contrast.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 local palette = {
   scale = scale,
@@ -53,81 +50,81 @@ local palette = {
   neutral = {
     emphasis = scale.gray[5],
     emphasis_plus = scale.gray[5],
-    muted = alpha(C.from_rgba(110, 118, 129, 1), 0.4),
-    subtle = alpha(C.from_rgba(110, 118, 129, 1), 0.1),
+    muted = BG:blend(C.from_rgba(110, 118, 129, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(110, 118, 129, 1), 0.1):to_css(),
   },
 
   accent = {
     fg = scale.blue[5],
     emphasis = scale.blue[6],
-    muted = alpha(C.from_rgba(56, 139, 253, 1), 0.4),
-    subtle = alpha(C.from_rgba(56, 139, 253, 1), 0.15),
+    muted = BG:blend(C.from_rgba(56, 139, 253, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(56, 139, 253, 1), 0.15):to_css(),
   },
 
   success = {
     fg = scale.green[5],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   attention = {
     fg = scale.yellow[5],
     emphasis = scale.yellow[6],
-    muted = alpha(C.from_rgba(187, 128, 9, 1), 0.4),
-    subtle = alpha(C.from_rgba(187, 128, 9, 1), 0.15),
+    muted = BG:blend(C.from_rgba(187, 128, 9, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(187, 128, 9, 1), 0.15):to_css(),
   },
 
   severe = {
     fg = scale.orange[5],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_rgba(219, 109, 40, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 109, 40, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 109, 40, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 109, 40, 1), 0.15):to_css(),
   },
 
   danger = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   open = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   done = {
     fg = scale.purple[5],
     emphasis = scale.purple[6],
-    muted = alpha(C.from_rgba(163, 113, 247, 1), 0.4),
-    subtle = alpha(C.from_rgba(163, 113, 247, 1), 0.15),
+    muted = BG:blend(C.from_rgba(163, 113, 247, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(163, 113, 247, 1), 0.15):to_css(),
   },
 
   closed = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   sponsors = {
     fg = scale.pink[5],
     emphasis = scale.pink[6],
-    muted = alpha(C.from_rgba(219, 97, 162, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 97, 162, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 97, 162, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 97, 162, 1), 0.15):to_css(),
   },
 }
 
 local function generate_spec(pal)
   -- stylua: ignore start
   local spec = {
-    bg0  = alpha(C(pal.canvas.inset), 0.75),            -- Dark bg (popup and float)
+    bg0  = BG:blend(C(pal.canvas.inset), 0.75):to_css(),         -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
-    bg3  = alpha(C(pal.fg.default), 0.1),               -- Lighter bg (cursor line)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
+    bg3  = BG:blend(C(pal.fg.default), 0.1):to_css(),            -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[4],                           -- Conceal
 
     fg0  = pal.fg.subtle,                               -- Lighter fg
@@ -135,9 +132,9 @@ local function generate_spec(pal)
     fg2  = pal.fg.muted,                                -- Darker fg (status line)
     fg3  = pal.scale.gray[5],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.30),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.scale.yellow[1]), 0.20),         -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.30):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.scale.yellow[1]), 0.20):to_css(),      -- Search bg
   }
 
   spec.syntax = {
@@ -173,16 +170,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[6]), 0.15),
-    delete = alpha(C(pal.scale.red[6]), 0.15),
-    change = alpha(C(pal.scale.yellow[6]), 0.15),
+    add    = BG:blend(C(pal.scale.green[6]), 0.15):to_css(),
+    delete = BG:blend(C(pal.scale.red[6]), 0.15):to_css(),
+    change = BG:blend(C(pal.scale.yellow[6]), 0.15):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_dark_tritanopia.lua
+++ b/lua/github-theme/palette/github_dark_tritanopia.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 local palette = {
   scale = scale,
@@ -47,86 +44,86 @@ local palette = {
   border = {
     default = scale.gray[7],
     muted = scale.gray[8],
-    subtle = alpha(C.from_rgba(240, 246, 252, 1), 0.1),
+    subtle = BG:blend(C.from_rgba(240, 246, 252, 1), 0.1):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[5],
     emphasis = scale.gray[5],
-    muted = alpha(C.from_rgba(110, 118, 129, 1), 0.4),
-    subtle = alpha(C.from_rgba(110, 118, 129, 1), 0.1),
+    muted = BG:blend(C.from_rgba(110, 118, 129, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(110, 118, 129, 1), 0.1):to_css(),
   },
 
   accent = {
     fg = scale.blue[4],
     emphasis = scale.blue[6],
-    muted = alpha(C.from_rgba(56, 139, 253, 1), 0.4),
-    subtle = alpha(C.from_rgba(56, 139, 253, 1), 0.15),
+    muted = BG:blend(C.from_rgba(56, 139, 253, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(56, 139, 253, 1), 0.15):to_css(),
   },
 
   success = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   attention = {
     fg = scale.yellow[4],
     emphasis = scale.yellow[6],
-    muted = alpha(C.from_rgba(187, 128, 9, 1), 0.4),
-    subtle = alpha(C.from_rgba(187, 128, 9, 1), 0.15),
+    muted = BG:blend(C.from_rgba(187, 128, 9, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(187, 128, 9, 1), 0.15):to_css(),
   },
 
   severe = {
     fg = scale.orange[5],
     emphasis = scale.orange[6],
-    muted = alpha(C.from_rgba(219, 109, 40, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 109, 40, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 109, 40, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 109, 40, 1), 0.15):to_css(),
   },
 
   danger = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   open = {
     fg = scale.green[4],
     emphasis = scale.green[6],
-    muted = alpha(C.from_rgba(46, 160, 67, 1), 0.4),
-    subtle = alpha(C.from_rgba(46, 160, 67, 1), 0.15),
+    muted = BG:blend(C.from_rgba(46, 160, 67, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(46, 160, 67, 1), 0.15):to_css(),
   },
 
   done = {
     fg = scale.purple[5],
     emphasis = scale.purple[6],
-    muted = alpha(C.from_rgba(163, 113, 247, 1), 0.4),
-    subtle = alpha(C.from_rgba(163, 113, 247, 1), 0.15),
+    muted = BG:blend(C.from_rgba(163, 113, 247, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(163, 113, 247, 1), 0.15):to_css(),
   },
 
   closed = {
     fg = scale.red[5],
     emphasis = scale.red[6],
-    muted = alpha(C.from_rgba(248, 81, 73, 1), 0.4),
-    subtle = alpha(C.from_rgba(248, 81, 73, 1), 0.15),
+    muted = BG:blend(C.from_rgba(248, 81, 73, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(248, 81, 73, 1), 0.15):to_css(),
   },
 
   sponsors = {
     fg = scale.pink[5],
     emphasis = scale.pink[6],
-    muted = alpha(C.from_rgba(219, 97, 162, 1), 0.4),
-    subtle = alpha(C.from_rgba(219, 97, 162, 1), 0.15),
+    muted = BG:blend(C.from_rgba(219, 97, 162, 1), 0.4):to_css(),
+    subtle = BG:blend(C.from_rgba(219, 97, 162, 1), 0.15):to_css(),
   },
 }
 
 local function generate_spec(pal)
   -- stylua: ignore start
   local spec = {
-    bg0  = alpha(C(pal.canvas.inset), 0.75),            -- Dark bg (popup and float)
+    bg0  = BG:blend(C(pal.canvas.inset), 0.75):to_css(),         -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
     bg3  = pal.scale.gray[6],                           -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[4],                           -- Conceal
 
@@ -135,9 +132,9 @@ local function generate_spec(pal)
     fg2  = pal.fg.muted,                                -- Darker fg (status line)
     fg3  = pal.scale.gray[5],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.30),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.scale.yellow[1]), 0.20),         -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.30):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.scale.yellow[1]), 0.20):to_css(),      -- Search bg
   }
 
   spec.syntax = {
@@ -173,16 +170,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[6]), 0.15),
-    delete = alpha(C(pal.scale.red[6]), 0.15),
-    change = alpha(C(pal.scale.yellow[6]), 0.15),
+    add    = BG:blend(C(pal.scale.green[6]), 0.15):to_css(),
+    delete = BG:blend(C(pal.scale.red[6]), 0.15):to_css(),
+    change = BG:blend(C(pal.scale.yellow[6]), 0.15):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_light.lua
+++ b/lua/github-theme/palette/github_light.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(scale.white)
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(scale.white)
 
 -- Temp override until Primitives are updated
 local palette = {
@@ -53,76 +50,76 @@ local palette = {
   border = {
     default = scale.gray[3],
     muted = C(scale.gray[3]):lighten(0.03), -- TODO: lighten method not working
-    subtle = alpha(C(scale.black), 0.15),
+    subtle = BG:blend(C(scale.black), 0.15):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[10],
     emphasis = scale.gray[6],
-    muted = alpha(C(scale.gray[4]), 0.2),
-    subtle = alpha(C(scale.gray[2]), 0.5),
+    muted = BG:blend(C(scale.gray[4]), 0.2):to_css(),
+    subtle = BG:blend(C(scale.gray[2]), 0.5):to_css(),
   },
 
   accent = {
     fg = scale.blue[6],
     emphasis = scale.blue[6],
-    muted = alpha(C(scale.blue[4]), 0.4),
+    muted = BG:blend(C(scale.blue[4]), 0.4):to_css(),
     subtle = scale.blue[1],
   },
 
   success = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   attention = {
     fg = scale.yellow[6],
     emphasis = scale.yellow[6],
-    muted = alpha(C(scale.yellow[4]), 0.4),
+    muted = BG:blend(C(scale.yellow[4]), 0.4):to_css(),
     subtle = scale.yellow[1],
   },
 
   severe = {
     fg = scale.orange[6],
     emphasis = scale.orange[6],
-    muted = alpha(C(scale.orange[4]), 0.4),
+    muted = BG:blend(C(scale.orange[4]), 0.4):to_css(),
     subtle = scale.orange[1],
   },
 
   danger = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   open = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   closed = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   done = {
     fg = scale.purple[6],
     emphasis = scale.purple[6],
-    muted = alpha(C(scale.purple[4]), 0.4),
+    muted = BG:blend(C(scale.purple[4]), 0.4):to_css(),
     subtle = scale.purple[1],
   },
 
   sponsors = {
     fg = scale.pink[6],
     emphasis = scale.pink[6],
-    muted = alpha(C(scale.pink[4]), 0.4),
+    muted = BG:blend(C(scale.pink[4]), 0.4):to_css(),
     subtle = scale.pink[1],
   },
 }
@@ -132,8 +129,8 @@ local function generate_spec(pal)
   local spec = {
     bg0  = pal.canvas.inset,                            -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
-    bg3  = alpha(C(pal.scale.blue[9]), 0.1),            -- Lighter bg (cursor line)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
+    bg3  = BG:blend(C(pal.scale.blue[9]), 0.1):to_css(),         -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[6],                           -- Conceal
 
     fg0  = pal.fg.subtle,                               -- Lighter fg
@@ -141,9 +138,9 @@ local function generate_spec(pal)
     fg2  = pal.scale.gray[9],                           -- Darker fg (status line)
     fg3  = pal.scale.gray[7],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.15),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.attention.emphasis), 0.3)        -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.15):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.attention.emphasis), 0.3):to_css()     -- Search bg
   }
 
   spec.syntax = {
@@ -179,16 +176,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[7]), 0.3),
-    delete = alpha(C(pal.scale.red[7]), 0.3),
-    change = alpha(C(pal.scale.yellow[7]), 0.3),
+    add    = BG:blend(C(pal.scale.green[7]), 0.3):to_css(),
+    delete = BG:blend(C(pal.scale.red[7]), 0.3):to_css(),
+    change = BG:blend(C(pal.scale.yellow[7]), 0.3):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_light_colorblind.lua
+++ b/lua/github-theme/palette/github_light_colorblind.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 -- Temp override until Primitives are updated
 local palette = {
@@ -48,76 +45,76 @@ local palette = {
   border = {
     default = scale.gray[3],
     muted = C(scale.gray[3]):lighten(0.03), -- TODO: lighten method not working
-    subtle = alpha(C(scale.black), 0.15),
+    subtle = BG:blend(C(scale.black), 0.15):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[10],
     emphasis = scale.gray[6],
-    muted = alpha(C(scale.gray[4]), 0.2),
-    subtle = alpha(C(scale.gray[2]), 0.5),
+    muted = BG:blend(C(scale.gray[4]), 0.2):to_css(),
+    subtle = BG:blend(C(scale.gray[2]), 0.5):to_css(),
   },
 
   accent = {
     fg = scale.blue[6],
     emphasis = scale.blue[6],
-    muted = alpha(C(scale.blue[4]), 0.4),
+    muted = BG:blend(C(scale.blue[4]), 0.4):to_css(),
     subtle = scale.blue[1],
   },
 
   success = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   attention = {
     fg = scale.yellow[6],
     emphasis = scale.yellow[6],
-    muted = alpha(C(scale.yellow[4]), 0.4),
+    muted = BG:blend(C(scale.yellow[4]), 0.4):to_css(),
     subtle = scale.yellow[1],
   },
 
   severe = {
     fg = scale.orange[6],
     emphasis = scale.orange[6],
-    muted = alpha(C(scale.orange[4]), 0.4),
+    muted = BG:blend(C(scale.orange[4]), 0.4):to_css(),
     subtle = scale.orange[1],
   },
 
   danger = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   open = {
     fg = scale.orange[6],
     emphasis = scale.orange[5],
-    muted = alpha(C(scale.orange[4]), 0.4),
+    muted = BG:blend(C(scale.orange[4]), 0.4):to_css(),
     subtle = scale.orange[1],
   },
 
   closed = {
     fg = scale.gray[6],
     emphasis = scale.gray[6],
-    muted = alpha(C(scale.gray[4]), 0.4),
+    muted = BG:blend(C(scale.gray[4]), 0.4):to_css(),
     subtle = scale.gray[1],
   },
 
   done = {
     fg = scale.purple[6],
     emphasis = scale.purple[6],
-    muted = alpha(C(scale.purple[4]), 0.4),
+    muted = BG:blend(C(scale.purple[4]), 0.4):to_css(),
     subtle = scale.purple[1],
   },
 
   sponsors = {
     fg = scale.pink[6],
     emphasis = scale.pink[6],
-    muted = alpha(C(scale.pink[4]), 0.4),
+    muted = BG:blend(C(scale.pink[4]), 0.4):to_css(),
     subtle = scale.pink[1],
   },
 }
@@ -127,8 +124,8 @@ local function generate_spec(pal)
   local spec = {
     bg0  = pal.canvas.inset,                            -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
-    bg3  = alpha(C(pal.scale.blue[9]), 0.1),            -- Lighter bg (cursor line)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
+    bg3  = BG:blend(C(pal.scale.blue[9]), 0.1):to_css(),         -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[6],                           -- Conceal
 
     fg0  = pal.fg.subtle,                               -- Lighter fg
@@ -136,9 +133,9 @@ local function generate_spec(pal)
     fg2  = pal.scale.gray[9],                           -- Darker fg (status line)
     fg3  = pal.scale.gray[7],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.15),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.attention.emphasis), 0.3)        -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.15):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.attention.emphasis), 0.3):to_css()     -- Search bg
   }
 
   spec.syntax = {
@@ -174,16 +171,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[7]), 0.3),
-    delete = alpha(C(pal.scale.red[7]), 0.3),
-    change = alpha(C(pal.scale.yellow[7]), 0.3),
+    add    = BG:blend(C(pal.scale.green[7]), 0.3):to_css(),
+    delete = BG:blend(C(pal.scale.red[7]), 0.3):to_css(),
+    change = BG:blend(C(pal.scale.yellow[7]), 0.3):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_light_default.lua
+++ b/lua/github-theme/palette/github_light_default.lua
@@ -13,10 +13,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 -- Temp override until Primitives are updated
 local palette = {
@@ -47,76 +44,76 @@ local palette = {
   border = {
     default = scale.gray[3],
     muted = C(scale.gray[3]):lighten(0.03), -- TODO: lighten method not working
-    subtle = alpha(C(scale.black), 0.15),
+    subtle = BG:blend(C(scale.black), 0.15):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[10],
     emphasis = scale.gray[6],
-    muted = alpha(C(scale.gray[4]), 0.2),
-    subtle = alpha(C(scale.gray[2]), 0.5),
+    muted = BG:blend(C(scale.gray[4]), 0.2):to_css(),
+    subtle = BG:blend(C(scale.gray[2]), 0.5):to_css(),
   },
 
   accent = {
     fg = scale.blue[6],
     emphasis = scale.blue[6],
-    muted = alpha(C(scale.blue[4]), 0.4),
+    muted = BG:blend(C(scale.blue[4]), 0.4):to_css(),
     subtle = scale.blue[1],
   },
 
   success = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   attention = {
     fg = scale.yellow[6],
     emphasis = scale.yellow[6],
-    muted = alpha(C(scale.yellow[4]), 0.4),
+    muted = BG:blend(C(scale.yellow[4]), 0.4):to_css(),
     subtle = scale.yellow[1],
   },
 
   severe = {
     fg = scale.orange[6],
     emphasis = scale.orange[6],
-    muted = alpha(C(scale.orange[4]), 0.4),
+    muted = BG:blend(C(scale.orange[4]), 0.4):to_css(),
     subtle = scale.orange[1],
   },
 
   danger = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   open = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   closed = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   done = {
     fg = scale.purple[6],
     emphasis = scale.purple[6],
-    muted = alpha(C(scale.purple[4]), 0.4),
+    muted = BG:blend(C(scale.purple[4]), 0.4):to_css(),
     subtle = scale.purple[1],
   },
 
   sponsors = {
     fg = scale.pink[6],
     emphasis = scale.pink[6],
-    muted = alpha(C(scale.pink[4]), 0.4),
+    muted = BG:blend(C(scale.pink[4]), 0.4):to_css(),
     subtle = scale.pink[1],
   },
 }
@@ -126,8 +123,8 @@ local function generate_spec(pal)
   local spec = {
     bg0  = pal.canvas.inset,                            -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
-    bg3  = alpha(C(pal.scale.blue[9]), 0.1),            -- Lighter bg (cursor line)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
+    bg3  = BG:blend(C(pal.scale.blue[9]), 0.1):to_css(),         -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[6],                           -- Conceal
 
     fg0  = pal.fg.subtle,                               -- Lighter fg
@@ -135,9 +132,9 @@ local function generate_spec(pal)
     fg2  = pal.scale.gray[9],                           -- Darker fg (status line)
     fg3  = pal.scale.gray[7],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.15),               -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.attention.emphasis), 0.3)        -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.15):to_css(),            -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.attention.emphasis), 0.3):to_css()     -- Search bg
   }
 
   spec.syntax = {
@@ -173,16 +170,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[7]), 0.3),
-    delete = alpha(C(pal.scale.red[7]), 0.3),
-    change = alpha(C(pal.scale.yellow[7]), 0.3),
+    add    = BG:blend(C(pal.scale.green[7]), 0.3):to_css(),
+    delete = BG:blend(C(pal.scale.red[7]), 0.3):to_css(),
+    change = BG:blend(C(pal.scale.yellow[7]), 0.3):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_light_high_contrast.lua
+++ b/lua/github-theme/palette/github_light_high_contrast.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 -- Temp override until Primitives are updated
 local palette = {
@@ -48,13 +45,13 @@ local palette = {
   border = {
     default = scale.gray[9],
     muted = scale.gray[5],
-    subtle = alpha(C(scale.black), 0.8),
+    subtle = BG:blend(C(scale.black), 0.8):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[10],
     emphasis = scale.gray[6],
-    muted = alpha(C(scale.gray[4]), 0.2),
+    muted = BG:blend(C(scale.gray[4]), 0.2):to_css(),
     subtle = scale.gray[2],
   },
 
@@ -82,7 +79,7 @@ local palette = {
   severe = {
     fg = scale.orange[6],
     emphasis = scale.orange[6],
-    muted = alpha(C(scale.orange[4]), 0.4),
+    muted = BG:blend(C(scale.orange[4]), 0.4):to_css(),
     subtle = scale.orange[4],
   },
 
@@ -96,14 +93,14 @@ local palette = {
   open = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   closed = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
@@ -127,7 +124,7 @@ local function generate_spec(pal)
   local spec = {
     bg0  = pal.canvas.inset,                            -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
     bg3  = pal.scale.gray[2],                           -- Lighter bg (cursor line)
     bg4  = pal.border.default,                          -- Conceal
 
@@ -136,9 +133,9 @@ local function generate_spec(pal)
     fg2  = pal.scale.gray[9],                           -- Darker fg (status line)
     fg3  = pal.scale.gray[7],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.2),                -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.attention.emphasis), 0.3)        -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.2):to_css(),             -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.attention.emphasis), 0.3):to_css()     -- Search bg
   }
 
   spec.syntax = {
@@ -174,16 +171,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[2]), 0.3),
-    delete = alpha(C(pal.scale.red[2]), 0.3),
-    change = alpha(C(pal.scale.yellow[2]), 0.3),
+    add    = BG:blend(C(pal.scale.green[2]), 0.3):to_css(),
+    delete = BG:blend(C(pal.scale.red[2]), 0.3):to_css(),
+    change = BG:blend(C(pal.scale.yellow[2]), 0.3):to_css(),
     text   = spec.fg0
   }
 

--- a/lua/github-theme/palette/github_light_tritanopia.lua
+++ b/lua/github-theme/palette/github_light_tritanopia.lua
@@ -14,10 +14,7 @@ local scale = primitives.scale
 C.WHITE = C(scale.white)
 C.BLACK = C(scale.black)
 C.BG = C(assert(primitives.canvas.default))
-
-local function alpha(color, a)
-  return color:alpha_blend(a):to_css()
-end
+local BG = C(assert(primitives.canvas.default))
 
 -- Temp override until Primitives are updated
 local palette = {
@@ -48,76 +45,76 @@ local palette = {
   border = {
     default = scale.gray[3],
     muted = C(scale.gray[3]):lighten(0.03), -- TODO: lighten method not working
-    subtle = alpha(C(scale.black), 0.15),
+    subtle = BG:blend(C(scale.black), 0.15):to_css(),
   },
 
   neutral = {
     emphasis_plus = scale.gray[10],
     emphasis = scale.gray[6],
-    muted = alpha(C(scale.gray[4]), 0.2),
-    subtle = alpha(C(scale.gray[2]), 0.5),
+    muted = BG:blend(C(scale.gray[4]), 0.2):to_css(),
+    subtle = BG:blend(C(scale.gray[2]), 0.5):to_css(),
   },
 
   accent = {
     fg = scale.blue[6],
     emphasis = scale.blue[6],
-    muted = alpha(C(scale.blue[4]), 0.4),
+    muted = BG:blend(C(scale.blue[4]), 0.4):to_css(),
     subtle = scale.blue[1],
   },
 
   success = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   attention = {
     fg = scale.yellow[6],
     emphasis = scale.yellow[6],
-    muted = alpha(C(scale.yellow[4]), 0.4),
+    muted = BG:blend(C(scale.yellow[4]), 0.4):to_css(),
     subtle = scale.yellow[1],
   },
 
   severe = {
     fg = scale.orange[6],
     emphasis = scale.orange[6],
-    muted = alpha(C(scale.orange[4]), 0.4),
+    muted = BG:blend(C(scale.orange[4]), 0.4):to_css(),
     subtle = scale.orange[1],
   },
 
   danger = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   open = {
     fg = scale.green[6],
     emphasis = '#1f883d',
-    muted = alpha(C(scale.green[4]), 0.4),
+    muted = BG:blend(C(scale.green[4]), 0.4):to_css(),
     subtle = scale.green[1],
   },
 
   closed = {
     fg = '#d1242f',
     emphasis = scale.red[6],
-    muted = alpha(C(scale.red[4]), 0.4),
+    muted = BG:blend(C(scale.red[4]), 0.4):to_css(),
     subtle = scale.red[1],
   },
 
   done = {
     fg = scale.purple[6],
     emphasis = scale.purple[6],
-    muted = alpha(C(scale.purple[4]), 0.4),
+    muted = BG:blend(C(scale.purple[4]), 0.4):to_css(),
     subtle = scale.purple[1],
   },
 
   sponsors = {
     fg = scale.pink[6],
     emphasis = scale.pink[6],
-    muted = alpha(C(scale.pink[4]), 0.4),
+    muted = BG:blend(C(scale.pink[4]), 0.4):to_css(),
     subtle = scale.pink[1],
   },
 }
@@ -127,7 +124,7 @@ local function generate_spec(pal)
   local spec = {
     bg0  = pal.canvas.inset,                            -- Dark bg (popup and float)
     bg1  = pal.canvas.default,                          -- Default bg
-    bg2  = alpha(C(pal.neutral.emphasis), 0.1),         -- Lighter bg (colorcolumn Folds)
+    bg2  = BG:blend(C(pal.neutral.emphasis), 0.1):to_css(),      -- Lighter bg (colorcolumn Folds)
     bg3  = pal.scale.gray[2],                           -- Lighter bg (cursor line)
     bg4  = pal.scale.gray[6],                           -- Conceal
 
@@ -136,9 +133,9 @@ local function generate_spec(pal)
     fg2  = pal.scale.gray[9],                           -- Darker fg (status line)
     fg3  = pal.scale.gray[7],                           -- Darker fg (line numbers, fold columns)
 
-    sel0 = alpha(C(pal.accent.fg), 0.2),                -- Visual selection bg
-    sel1 = alpha(C(pal.accent.muted), 0.90),            -- Popup sel bg
-    sel2 = alpha(C(pal.attention.emphasis), 0.3)        -- Search bg
+    sel0 = BG:blend(C(pal.accent.fg), 0.2):to_css(),             -- Visual selection bg
+    sel1 = BG:blend(C(pal.accent.muted), 0.90):to_css(),         -- Popup sel bg
+    sel2 = BG:blend(C(pal.attention.emphasis), 0.3):to_css()     -- Search bg
   }
 
   spec.syntax = {
@@ -174,16 +171,16 @@ local function generate_spec(pal)
   }
 
   spec.diag_bg = {
-    error = C(spec.bg1):blend(C(spec.diag.error), 0.15):to_css(),
-    warn  = C(spec.bg1):blend(C(spec.diag.warn), 0.15):to_css(),
-    info  = C(spec.bg1):blend(C(spec.diag.info), 0.15):to_css(),
-    hint  = C(spec.bg1):blend(C(spec.diag.hint), 0.15):to_css(),
+    error = BG:blend(C(spec.diag.error), 0.15):to_css(),
+    warn  = BG:blend(C(spec.diag.warn), 0.15):to_css(),
+    info  = BG:blend(C(spec.diag.info), 0.15):to_css(),
+    hint  = BG:blend(C(spec.diag.hint), 0.15):to_css(),
   }
 
   spec.diff = {
-    add    = alpha(C(pal.scale.green[2]), 0.3),
-    delete = alpha(C(pal.scale.red[2]), 0.3),
-    change = alpha(C(pal.scale.yellow[2]), 0.3),
+    add    = BG:blend(C(pal.scale.green[2]), 0.3):to_css(),
+    delete = BG:blend(C(pal.scale.red[2]), 0.3):to_css(),
+    change = BG:blend(C(pal.scale.yellow[2]), 0.3):to_css(),
     text   = spec.fg0
   }
 

--- a/test/github-theme/color_spec.lua
+++ b/test/github-theme/color_spec.lua
@@ -224,7 +224,7 @@ describe('Color', function()
     end)
   end)
 
-  describe('global state `Color.{WHITE,BLACK,BG}`', function()
+  describe('global fields/state `Color.{WHITE,BLACK,BG}`', function()
     local theme = 'github_dark_dimmed'
     before_each(function()
       require('github-theme.util.reload')(true)
@@ -232,7 +232,7 @@ describe('Color', function()
     end)
 
     -- See #362
-    it('should not disrupt palette/spec', function()
+    it('should not disrupt colors in palette/spec/groups', function()
       local groups_expected = require('github-theme.group').load(theme)
       require('github-theme.util.reload')(true)
 
@@ -256,8 +256,9 @@ describe('Color', function()
 
       local function index(_, k)
         if k == 'BG' or k == 'WHITE' or k == 'BLACK' then
-          error(debug.traceback('Color.' .. k .. ' was accessed internally'))
+          error('Color.' .. k .. ' was accessed internally', 2)
         end
+
         return rawget(C --[[@as table]], k)
       end
 


### PR DESCRIPTION
Fix bug where the colorscheme colors are off/incorrect when a palette is `require()`'d, whether directly or indirectly, anytime before compilation occurs (e.g. compilation that occurs during colorscheme load). For details, see issue #362.

Also, add a test (in `test/`) which disallows the direct or indirect use of the global static/class fields of the `Color` class (e.g. `Color.BG`).

Fixes: #362