### PR TITLE
docs(README): specify `name` field in lazy.nvim installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ Add this in your `init.lua` or `plugins.lua`
 
 ```lua
 -- Install without configuration
-{ 'projekt0n/github-nvim-theme' }
+{ 'projekt0n/github-nvim-theme', name = 'github-theme' }
 
 -- Or with configuration
 {
   'projekt0n/github-nvim-theme',
+  name = 'github-theme',
   lazy = false, -- make sure we load this during startup if it is your main colorscheme
   priority = 1000, -- make sure to load this before all the other start plugins
   config = function()


### PR DESCRIPTION
If you try to install this colorscheme using lazy.nvim in the following way
```lua
{
  "projekt0n/github-nvim-theme",
  opts = {
    options = {
      transparent = true,
    },
  }
}
```
i.e., specifying some options in the `opts` field instead of using `config`, lazy cannot find the plugin.

To automatically call `setup` with the values of `opts`, it has to infer the name of the plugin from `projekt0n/github-nvim-theme`, resulting in `github-nvim-theme`. However, the plugin must be required with `require('github-theme')`.

You can manually specify the name of the plugin using the `name` field:
```lua
{
  "projekt0n/github-nvim-theme",
  name = "github-theme",
  opts = {
    options = {
      transparent = true,
    },
  }
}
```