### PR TITLE
fix(treesitter): elixir module/atom colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 -  Fixed JSX/TSX tags are missing highlights with nvim 0.10 (#360)
 -  Fixed loading palette or spec before colorscheme disrupts colors (#362 fixed-by #363)
 -  Fixed incorrect highlight of name/binding in python import statements (#371)
+-  Fixed elixir module/atom colors (#366)
 
 ## [v1.1.2] - 05 August 2024
 

--- a/lua/github-theme/group/modules/treesitter.lua
+++ b/lua/github-theme/group/modules/treesitter.lua
@@ -307,6 +307,10 @@ If you want to stay on nvim 0.7, disable the module, or track on 'v0.0.x' branch
     ['@label.ruby']                             = { fg = syn.const },
     ['@string.special.symbol.ruby']             = { link = '@constant' },
 
+    -- Elixir
+    ['@string.special.symbol.elixir']           = { link = '@constant' },
+    ['@module.elixir']                          = { link = '@type' },
+
     -- Rust
     ['@constant.builtin.rust']                     = { fg = pl.syntax.variable },
     ['@module.rust']                               = FALLBACK_OR_NONE,

--- a/lua/github-theme/group/modules/treesitter.lua
+++ b/lua/github-theme/group/modules/treesitter.lua
@@ -80,7 +80,7 @@ If you want to stay on nvim 0.7, disable the module, or track on 'v0.0.x' branch
     ['@string.escape']            = { fg = syn.regex, style = 'bold' },                         -- Escape characters within a string: `\n`, `\t`, etc.
 
  -- ['@string.special']           = { link = 'Special' },                                       -- Other special strings (e.g. dates)
-    ['@string.special.symbol']    = { fg = syn.preproc },                                       -- Symbols or atoms
+    ['@string.special.symbol']    = { link = '@constant' },                                     -- Symbols or atoms
     ['@string.special.url']       = { fg = syn.const, style = 'italic,underline'  },            -- URIs (e.g. hyperlinks)
  -- ['@string.special.path']      = { fg = spec.palette.done.fg  },                             -- Filenames
 
@@ -308,7 +308,6 @@ If you want to stay on nvim 0.7, disable the module, or track on 'v0.0.x' branch
     ['@string.special.symbol.ruby']             = { link = '@constant' },
 
     -- Elixir
-    ['@string.special.symbol.elixir']           = { link = '@constant' },
     ['@module.elixir']                          = { link = '@type' },
 
     -- Rust


### PR DESCRIPTION
## Fixes highlighting of Modules/atoms in Elixir

### Before

![before](https://github.com/user-attachments/assets/c177c145-ad72-4594-9168-88aec3d7d1ce)

### After

![after](https://github.com/user-attachments/assets/f380038a-0426-4ec6-8479-04c3c8b1e104)