### PR TITLE
feat(blink.cmp): add support for blink.cmp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ This command will attach an autocmd to the current buffer that executes on `Buff
 -   [vim-airline](https://github.com/vim-airline/vim-airline)
 -   [vim-gitgutter](https://github.com/airblade/vim-gitgutter)
 -   [which-key.nvim](https://github.com/folke/which-key.nvim)
+-   [blink.cmp](https://github.com/Saghen/blink.cmp)
 
 ## Status lines
 

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -175,6 +175,7 @@ M.module_names = {
   'treesitter',
   'treesitter_context',
   'whichkey',
+  'blink_cmp',
 }
 
 ---@param name GhTheme.Theme

--- a/lua/github-theme/group/modules/blink_cmp.lua
+++ b/lua/github-theme/group/modules/blink_cmp.lua
@@ -1,0 +1,57 @@
+-- https://github.com/Saghen/blink.cmp
+
+local M = {}
+
+---@param spec GhTheme.Spec
+---@param config GhTheme.Config.Options
+---@param _opts GhTheme.Config.Module
+function M.get(spec, config, _opts)
+  local has_ts = config.modules.treesitter == true
+    or type(config.modules.treesitter) == 'table' and config.modules.treesitter.enable
+  local syn = spec.syntax
+
+  -- stylua: ignore
+  ---@type table<string, GhTheme.HighlightGroup>
+  return {
+    BlinkCmpMenu              = { fg = spec.fg1, bg = spec.bg1 },
+    BlinkCmpMenuBorder        = { link = 'FloatBorder' },
+
+    BlinkCmpDoc               = { fg = spec.fg1, bg = spec.bg1 },
+    BlinkCmpDocBorder         = { link = 'FloatBorder' },
+    BlinkCmpDocSeparator      = { link = 'FloatBorder' },
+
+    BlinkCmpSource            = { link = 'Comment' },
+
+    BlinkCmpLabel             = { fg = spec.fg1, },
+    BlinkCmpLabelDeprecated   = { fg = syn.dep, style = 'strikethrough' },
+    BlinkCmpLabelMatch        = { fg = syn.func, },
+    BlinkCmpLabelDetail       = { link = 'Comment' },
+    BlinkCmpLabelDescription  = { link = 'Comment' },
+
+    BlinkCmpKind              = { fg = spec.fg2, },
+    BlinkCmpKindKeyword       = { link = 'Keyword' },
+    BlinkCmpKindVariable      = { link = has_ts and '@variable' or  'Identifier' },
+    BlinkCmpKindConstant      = { link = has_ts and '@constant' or 'Constant' },
+    BlinkCmpKindReference     = { link = 'Keyword' },
+    BlinkCmpKindValue         = { link = 'Keyword' },
+
+    BlinkCmpKindFunction      = { link = 'Function' },
+    BlinkCmpKindMethod        = { link = 'Function' },
+    BlinkCmpKindConstructor   = { link = has_ts and '@constructor' or 'Type' },
+    BlinkCmpKindInterface     = { link = 'Constant' },
+    BlinkCmpKindEvent         = { link = 'Constant' },
+    BlinkCmpKindEnum          = { link = 'Constant' },
+    BlinkCmpKindUnit          = { link = 'Constant' },
+    BlinkCmpKindClass         = { link = 'Type' },
+    BlinkCmpKindStruct        = { link = 'Type' },
+    BlinkCmpKindModule        = { link = has_ts and '@module'  or 'Identifier' },
+    BlinkCmpKindProperty      = { link = has_ts and '@property' or  'Identifier' },
+    BlinkCmpKindField         = { link = has_ts and '@variable.member' or 'Identifier' },
+    BlinkCmpKindTypeParameter = { link = has_ts and '@variable.member' or 'Identifier' },
+    BlinkCmpKindEnumMember    = { link = has_ts and '@variable.member' or 'Identifier' },
+    BlinkCmpKindOperator      = { link = 'Operator' },
+    BlinkCmpKindSnippet       = { fg = spec.fg2 },
+  }
+end
+
+return M


### PR DESCRIPTION
Add highlight support for [blink.cmp](https://github.com/Saghen/blink.cmp).

blink.cmp has some [builtin highlights mapping from cmp](https://github.com/Saghen/blink.cmp/blob/main/lua/blink/cmp/highlights.lua), so most highlights in this PR was token from it.

There are two points I think worth to specifically mention:

- Border highlight group related
  + I found highlight `CmpDocumentationBorder` for [current cmp module](https://github.com/projekt0n/github-nvim-theme/blob/0e4636f556880d13c00d8a8f686fae8df7c9845f/lua/github-theme/group/modules/cmp.lua#L17) is actually invalid. [Corresponding highlight in cmp](https://github.com/hrsh7th/nvim-cmp/blob/1d572527440e6a9a5294055e37d288140271ac63/lua/cmp/config/window.lua#L7) seems like to be `FloatBorder`. 
  + so in this PR `BlinkCmpMenuBorder`、 `BlinkCmpDocBorder ` is linked to `FloatBorder` too.
- Doc separator  highlight group
  + cmp seems handle separator as markdown separator `---`, but blink.cmp has standalone highlight group `BlinkCmpDocSeparator` 
  + personally I think separator highlight like border looks better, so here `BlinkCmpDocSeparator` is also linked to `FloatBorder` first ( like `BlinkCmpDocBorder `)
  
Love this awesome theme, thanks for your great work. Tell me anything if I can help :)

---

Screenshots (github-light and github-dark)

- blink.cmp 
![image](https://github.com/user-attachments/assets/7bc020cc-1e2f-4206-bf24-33df259c29b1)
![image](https://github.com/user-attachments/assets/2c18b88e-8814-4453-83f6-1782e443218a)

- cmp
![image](https://github.com/user-attachments/assets/2890a0b0-ffcf-443f-952a-5788d087de3e)
![image](https://github.com/user-attachments/assets/3441e678-3d7e-43bd-9db4-5ac0762e1ee1)

