### PR TITLE
feat(config): add set_vim_background option

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ require('github-theme').setup({
     terminal_colors = true,    -- Set terminal colors (vim.g.terminal_color_*) used in `:terminal`
     dim_inactive = false,      -- Non focused panes set to alternative background
     module_default = true,     -- Default enable value for modules
+    set_vim_background = true, -- Automatically set vim.opt.background to 'light' or 'dark'
     styles = {                 -- Style to be applied to different syntax groups
       comments = 'NONE',       -- Value is any valid attr-list value `:help attr-list`
       functions = 'NONE',

--- a/doc/github-nvim-theme.txt
+++ b/doc/github-nvim-theme.txt
@@ -279,6 +279,10 @@ options.module_default {bool}       *github-nvim-theme-options.module_default*
 Specifies the default value of a module that has not been overridden in the
 modules table.
 
+options.set_vim_background {bool}*github-nvim-theme-options.set_vim_background*
+
+Automatically set `vim.opt.background` to the appropriate `'dark'` or `'light'`.
+
 
 options.styles {table}                      *github-nvim-theme-options.styles*
 

--- a/lua/github-theme/config.lua
+++ b/lua/github-theme/config.lua
@@ -27,6 +27,7 @@ local M = { theme = 'github_dark', has_options = false }
 ---@field inverse? GhTheme.Config.Options.Inverse
 ---@field darken? GhTheme.Config.Options.Darken
 ---@field modules? GhTheme.Config.Options.Modules
+---@field set_vim_background? boolean
 local defaults = {
   compile_file_suffix = '_compiled',
   compile_path = util.join_paths(util.cache_home, 'github-theme'),
@@ -36,6 +37,7 @@ local defaults = {
   terminal_colors = true,
   dim_inactive = false,
   module_default = true,
+  set_vim_background = true,
 
   ---A table of syntax items/groups and their corresponding styles.
   ---@class (exact) GhTheme.Config.Options.Styles

--- a/lua/github-theme/lib/compiler.lua
+++ b/lua/github-theme/lib/compiler.lua
@@ -33,6 +33,8 @@ function M.compile(opts)
   local groups = require('github-theme.group').from(spec)
   local background = spec.palette.meta.light and 'light' or 'dark'
 
+  local set_background = fmt([[vim.o.background = "%s"]], background)
+
   local lines = {
     fmt(
       [[
@@ -43,10 +45,10 @@ if vim.g.colors_name then
   vim.g.colors_name = nil
 end
 vim.o.termguicolors = true
-vim.o.background = "%s"
+%s
 vim.g.colors_name = "%s"
 ]],
-      background,
+      config.options.set_vim_background and set_background or "",
       opts.theme
     ),
   }


### PR DESCRIPTION
Add `set_vim_background` option (default `true`) to control whether or not `vim.opt.background = '...'` is included in compiler output. 

There are no breaking changes here; just the ability to opt out of the plugin setting
`vim.o.background`.

## Why? 

Neovim 0.11.0 introduced the ability to auto-detect the system's color theme, updating `vim.o.background` accordingly. However, this only works if the user has not set `vim.o.background` in their configuration already.

## Example

### Config (using folke/lazy.nvim)

<img width="396" height="485" alt="SCR-20251002-nvaa" src="https://github.com/user-attachments/assets/2192f565-5eef-4048-9b8a-3005f187499f" />

### Default (Pre-existing) Behavior

`options.set_vim_background = true` (equivalent to the behavior before this PR).

https://github.com/user-attachments/assets/30fe2c8c-d612-488a-9273-a769321d1ff7

Notice that the `OptionSet` autocommand doesn't run. This is because the `colorscheme github_default_dark` will set `vim.o.background = 'dark'`.


### Feature

`options.set_vim_background = false` 

https://github.com/user-attachments/assets/738a70b5-b2fb-46f9-bf14-122dc99158c6

Notice that now, the `OptionSet` autocommand does run, and the `vim.o.background` gets updated by Neovim.